### PR TITLE
chore(build) remove tarball upload from dist

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -83,6 +83,7 @@ tasks:
             mkdir tmp
             cd tmp
             npm pack ../
+            mv mongodb-stitch-*.tgz mongodb-stitch.tgz
 
       - command: s3.put
         params:
@@ -127,6 +128,17 @@ tasks:
           permissions: public-read
           content_type: application/javascript
           display_name: Stitch Javascript Library for Web (minified)
+
+      - command: s3.put
+        params:
+          aws_key: ${sdks_aws_key}
+          aws_secret: ${sdks_aws_secret}
+          local_file: stitch-js-sdk/tmp/mongodb-stitch.tgz
+          remote_file: js/npm/${task_id}/stitch.tgz
+          bucket: stitch-sdks
+          permissions: public-read
+          content_type: application/gzip
+          display_name: Stitch NPM package
 
   - name: docs_dist
     depends_on:

--- a/.evg.yml
+++ b/.evg.yml
@@ -128,17 +128,6 @@ tasks:
           content_type: application/javascript
           display_name: Stitch Javascript Library for Web (minified)
 
-      - command: s3.put
-        params:
-          aws_key: ${sdks_aws_key}
-          aws_secret: ${sdks_aws_secret}
-          local_file: stitch-js-sdk/tmp/stitch-0.0.12.tgz
-          remote_file: js/npm/${branch_name}/stitch.tgz
-          bucket: stitch-sdks
-          permissions: public-read
-          content_type: application/gzip
-          display_name: Stitch NPM package
-
   - name: docs_dist
     depends_on:
       - name: run_tests


### PR DESCRIPTION
I don't think we need to do this anymore since we publish to NPM