### PR TITLE
STITCH-539 - Auth methods return only authed userId in body

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "query-string": "^4.3.4"
   },
   "devDependencies": {
-    "babel-core": "^6.24.1",
     "babel-cli": "^6.24.1",
+    "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
     "babel-loader": "^7.0.0",

--- a/src/auth/providers.js
+++ b/src/auth/providers.js
@@ -27,13 +27,12 @@ function getDeviceInfo(deviceId, appId, appVersion = '') {
 
 function anonProvider(auth) {
   return {
-    login: (opts) => {
-      // reuse existing auth if present
-      const authData = auth.get();
-      if (authData.hasOwnProperty('accessToken')) {
-        return Promise.resolve(authData);
-      }
-
+    /**
+     * Login to a stitch application using anonymous authentication
+     *
+     * @returns {Promise} a promise that resolves when authentication succeeds.
+     */
+    authenticate: () => {
       const device = getDeviceInfo(auth.getDeviceId(), !!auth.client && auth.client.clientAppID);
       const fetchArgs = common.makeFetchArgs('GET');
       fetchArgs.cors = true;
@@ -53,10 +52,11 @@ function userPassProvider(auth) {
      *
      * @param {String} username the username to use for authentication
      * @param {String} password the password to use for authentication
-     * @returns {Promise}
+     * @returns {Promise} a promise that resolves when authentication succeeds.
      */
-    login: (username, password, opts) => {
+    authenticate: ({ username, password }) => {
       const device = getDeviceInfo(auth.getDeviceId(), !!auth.client && auth.client.clientAppID);
+
       const fetchArgs = common.makeFetchArgs(
         'POST',
         JSON.stringify({ username, password, options: { device } })

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -31,28 +31,42 @@ describe('Auth', () => {
   beforeEach(() => { test.fetch = sinon.stub(window, 'fetch'); });
   afterEach(() => test.fetch.restore());
 
-  it('should allow the user to retrieve profile information', () => {
-    window.fetch.resolves(mockApiResponse());
-    let client = new StitchClient();
-    return client.login()
-      .then(() => {
-        // console.log(test.fetch.getCall(0).args);
-      });
-  });
-
   it('should return a promise for anonymous login with existing auth data', () => {
     window.fetch.resolves(mockApiResponse());
+    expect.assertions(1)
+
     let client = new StitchClient();
     client.auth.storage.set(common.USER_AUTH_KEY, mockAuthData());
 
     return client.login()
-      .then(data => {
-        expect(data).toEqual({
-          accessToken: 'fake-access-token',
-          refreshToken: 'fake-refresh-token',
-          userId: 'fake-user-id',
-          deviceId: 'fake-device-id'
-        });
-      });
+      .then(userId => expect(userId).toEqual('fake-user-id'));
+  });
+
+  it('should return a promise for login with only new auth data userId', () => {
+    window.fetch.resolves(mockApiResponse({
+      body: {
+        accessToken: 'fake-access-token',
+        refreshToken: 'fake-refresh-token',
+        userId: 'fake-user-id',
+        deviceId: 'fake-device-id'
+      }
+    }));
+    expect.assertions(1)
+
+    let client = new StitchClient();
+
+    return client.login('email', 'password')
+      .then(userId => expect(userId).toEqual('fake-user-id'));
+  });
+
+  it('should return a promise for login with only existing auth data userId', () => {
+    window.fetch.resolves(mockApiResponse());
+    expect.assertions(1)
+
+    let client = new StitchClient();
+    client.auth.storage.set(common.USER_AUTH_KEY, mockAuthData());
+
+    return client.login('email', 'password')
+      .then(userId => expect(userId).toEqual('fake-user-id'));
   });
 });


### PR DESCRIPTION
* Remove `login( ... )` method from anon & userpass providers (replace with authenticate methods)
* Move "if auth exists, re-use" logic to Stitch client's authenticate method (rather than living in auth provider's login method)
* Returns `json.userId` from Stitch client's authenticate method