### PR TITLE
Allow override of public+client API version subpaths (defaults to 1.0)

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -30,10 +30,20 @@ class StitchClient {
 
     this.clientAppID = clientAppID;
 
-    this.appUrl = `${baseUrl}/api/public/v1.0`;
-    this.authUrl = `${baseUrl}/api/public/v1.0/auth`;
+    let publicAPIVersionSubpath = 'v1.0';
+    if (options && options.publicAPIVersionSubpath) {
+      publicAPIVersionSubpath = options.publicAPIVersionSubpath;
+    }
+
+    let clientAPIVersionSubpath = 'v1.0';
+    if (options && options.clientAPIVersionSubpath) {
+      clientAPIVersionSubpath = options.clientAPIVersionSubpath;
+    }
+
+    this.appUrl = `${baseUrl}/api/public/${publicAPIVersionSubpath}`;
+    this.authUrl = `${baseUrl}/api/public/${publicAPIVersionSubpath}/auth`;
     if (clientAppID) {
-      this.appUrl = `${baseUrl}/api/client/v1.0/app/${clientAppID}`;
+      this.appUrl = `${baseUrl}/api/client/${clientAPIVersionSubpath}/app/${clientAppID}`;
       this.authUrl = `${this.appUrl}/auth`;
     }
 


### PR DESCRIPTION
This is a precursor to splitting off the JS SDK's admin api, and allowing it to call against the v2 endpoints