### PR TITLE
Fix auth providers crud sdk test

### DIFF
--- a/test/admin/authProviders.test.js
+++ b/test/admin/authProviders.test.js
@@ -52,8 +52,8 @@ describe('Auth Providers V2', ()=>{
   it('enabling auth provider should work', async () => {
     let newAuthProvider = await authProviders.create({type: 'local-userpass', config: validConfig, disabled: true});
     expect(newAuthProvider.type).toEqual('local-userpass');
-    // getting the auth provider should fail because we don't return disabled users
-    await expect(authProviders.authProvider(newAuthProvider._id).get()).rejects.toBeDefined();
+    let fetchedProvider = await authProviders.authProvider(newAuthProvider._id).get();
+    expect(newAuthProvider._id).toEqual(fetchedProvider._id);
     await authProviders.authProvider(newAuthProvider._id).enable();
     let provider = await authProviders.authProvider(newAuthProvider._id).get();
     expect(provider.type).toEqual(provider.type);
@@ -65,8 +65,8 @@ describe('Auth Providers V2', ()=>{
     let provider = await authProviders.authProvider(newAuthProvider._id).get();
     expect(provider.disabled).toEqual(false);
     await authProviders.authProvider(newAuthProvider._id).disable();
-    // getting the auth provider should fail because we don't return disabled users
-    await expect(authProviders.authProvider(newAuthProvider._id).get()).rejects.toBeDefined();
+    provider = await authProviders.authProvider(newAuthProvider._id).get();
+    expect(provider.disabled).toEqual(true);
   });
   it('deleting an auth provider should work', async () => {
     let newAuthProvider = await authProviders.create({type: 'local-userpass', config: validConfig});

--- a/test/admin/pipelines.test.js
+++ b/test/admin/pipelines.test.js
@@ -48,7 +48,7 @@ describe('Pipelines V2', ()=>{
     delete deepPipeline.pipeline;
     delete deepPipeline.output;
     delete deepPipeline.private;
-    delete deepPipeline.skipRules;
+    delete deepPipeline.skip_rules;
     expect(pipeline).toEqual(deepPipeline);
   });
   it('can update a pipeline', async () => {


### PR DESCRIPTION
@haleyowen 
Since we made the server-side change to include disabled auth providers, I think this test needed an update. I updated the change for enable/disable to what I think it should be; it seems to fix the "disable auth provider" test, but not the "enable" one - I'm not sure why. Any ideas?