### PR TITLE
STITCH-870 - StitchClient for apps uses API v2.0; Admin v3 uses /admin/v3.0

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -242,7 +242,7 @@ export default class Admin extends StitchClient {
             return super._do(
               `/groups/${groupId}/apps/${appID}/sandbox/pipeline`,
               'POST',
-              {body: JSON.stringify(data), queryParams});
+              {body: JSON.stringify(data), queryParams, apiVersion: v1});
           }
         }),
 

--- a/src/auth/common.js
+++ b/src/auth/common.js
@@ -11,10 +11,10 @@ export const STITCH_LINK_KEY = '_stitch_link';
 export const DEFAULT_ACCESS_TOKEN_EXPIRE_WITHIN_SECS = 10;
 
 export const APP_CLIENT_CODEC = {
-  'accessToken': 'accessToken',
-  'refreshToken': 'refreshToken',
-  'deviceId': 'deviceId',
-  'userId': 'userId'
+  'accessToken': 'access_token',
+  'refreshToken': 'refresh_token',
+  'deviceId': 'device_id',
+  'userId': 'user_id'
 };
 
 export  const ADMIN_CLIENT_CODEC = {

--- a/src/auth/providers.js
+++ b/src/auth/providers.js
@@ -46,7 +46,7 @@ function anonProvider(auth) {
       const fetchArgs = common.makeFetchArgs('GET');
       fetchArgs.cors = true;
 
-      return fetch(`${auth.rootUrl}/anon/user?device=${uriEncodeObject(device)}`, fetchArgs)
+      return fetch(`${auth.rootUrl}/providers/anon-user/login?device=${uriEncodeObject(device)}`, fetchArgs)
         .then(common.checkStatus)
         .then(response => response.json())
         .then(json => auth.set(json));
@@ -56,8 +56,8 @@ function anonProvider(auth) {
 
 /** @namespace */
 function userPassProvider(auth) {
-  const providerRoute = auth.isAppClient() ? 'local/userpass' : 'providers/local-userpass';
-  const loginRoute = auth.isAppClient() ? 'local/userpass' : `${providerRoute}/login`;
+  const providerRoute = auth.isAppClient() ? 'providers/local-userpass' : 'providers/local-userpass';
+  const loginRoute = auth.isAppClient() ? `${providerRoute}/login` : `${providerRoute}/login`;
 
   return {
     /**
@@ -182,7 +182,7 @@ function userPassProvider(auth) {
 
 /** @namespace */
 function apiKeyProvider(auth) {
-  const loginRoute = auth.isAppClient() ? 'api/key' : 'providers/api-key/login';
+  const loginRoute = auth.isAppClient() ? 'providers/api-key/login' : 'providers/api-key/login';
 
   return {
     /**
@@ -237,7 +237,7 @@ function getOAuthLoginURL(auth, providerName, redirectUrl) {
 
   const device = getDeviceInfo(auth.getDeviceId(), !!auth.client && auth.client.clientAppID);
 
-  const result = `${auth.rootUrl}/oauth2/${providerName}?redirect=${encodeURI(redirectUrl)}&state=${state}&device=${uriEncodeObject(device)}`;
+  const result = `${auth.rootUrl}/oauth2-${providerName}?redirect=${encodeURI(redirectUrl)}&state=${state}&device=${uriEncodeObject(device)}`;
   return result;
 }
 
@@ -281,7 +281,7 @@ function facebookProvider(auth) {
 
 /** @namespace */
 function mongodbCloudProvider(auth) {
-  const loginRoute = auth.isAppClient() ? 'mongodb/cloud' : 'providers/mongodb-cloud/login';
+  const loginRoute = auth.isAppClient() ? 'providers/mongodb-cloud/login' : 'providers/mongodb-cloud/login';
 
   return {
     /**

--- a/test/admin/api_keys.test.js
+++ b/test/admin/api_keys.test.js
@@ -21,13 +21,19 @@ describe('API Keys V2', () => {
       .apiKeys();
 
     // enable api key auth provider
-    // TODO: update this to use `apps.app(app._id).authProviders...` once V2 is ready
-    await adminClient
+    let providers = await adminClient
+      .v2()
       .apps(test.groupId)
       .app(app._id)
       .authProviders()
-      .provider('api', 'key')
-      .update({});
+      .list();
+    await adminClient
+      .v2()
+      .apps(test.groupId)
+      .app(app._id)
+      .authProviders()
+      .authProvider(providers[0]._id)
+      .enable();
   });
   afterEach(async () => {
     await apps.app(app._id).remove();

--- a/test/admin/app.test.js
+++ b/test/admin/app.test.js
@@ -1,43 +1,6 @@
 const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 import {getAuthenticatedClient} from '../testutil';
 
-
-describe('Apps V1', ()=>{
-  let test = new StitchMongoFixture();
-  let apiV1;
-  beforeAll(() => test.setup());
-  afterAll(() => test.teardown());
-  beforeEach(async () =>{
-    let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
-    test.groupId = test.userData.group.groupId;
-    apiV1 = adminClient;
-  });
-
-  it('listing apps should return empty list', async () => {
-    let apps = await apiV1.apps(test.groupId).list();
-    expect(apps).toEqual([]);
-  });
-
-  const testAppName = 'testapp';
-  it('can create an app successfully', async () => {
-    const app = await apiV1.apps(test.groupId).create({name: testAppName});
-    expect(app.name).toEqual(testAppName);
-    const apps = await apiV1.apps(test.groupId).list();
-    expect(apps).toHaveLength(1);
-    expect(apps[0]).toEqual(app);
-  });
-  it('can fetch an existing app', async () => {
-    const app = await apiV1.apps(test.groupId).create({name: testAppName});
-    const appFetched = await apiV1.apps(test.groupId).app(app._id).get();
-    expect(app).toEqual(appFetched);
-  });
-  it('can delete an app', async () => {
-    let app = await apiV1.apps(test.groupId).create({name: testAppName});
-    await apiV1.apps(test.groupId).app(app._id).remove();
-    const apps = (await apiV1.apps(test.groupId).list()).filter(x => x._id === app._id);
-    expect(apps).toHaveLength(0);
-  });
-});
 describe('Apps V2', ()=>{
   let test = new StitchMongoFixture();
   let apiV2;

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -45,10 +45,10 @@ describe('Auth', () => {
   it('should return a promise for login with only new auth data userId', () => {
     window.fetch.resolves(mockApiResponse({
       body: {
-        accessToken: 'fake-access-token',
-        refreshToken: 'fake-refresh-token',
-        userId: 'fake-user-id',
-        deviceId: 'fake-device-id'
+        access_token: 'fake-access-token',
+        refresh_token: 'fake-refresh-token',
+        user_id: 'fake-user-id',
+        device_id: 'fake-device-id'
       }
     }));
     expect.assertions(1);

--- a/test/services/aws_s3.test.js
+++ b/test/services/aws_s3.test.js
@@ -8,7 +8,7 @@ TestFixture.prototype.setup = function() {
 };
 
 const test = new TestFixture();
-describe('S3Service', function() {
+describe.skip('S3Service', function() {
   describe('substages', () => {
     beforeEach(() => test.setup());
 

--- a/test/services/aws_ses.test.js
+++ b/test/services/aws_ses.test.js
@@ -8,7 +8,7 @@ TestFixture.prototype.setup = function() {
 };
 
 const test = new TestFixture();
-describe('SESService', function() {
+describe.skip('SESService', function() {
   describe('substages', () => {
     beforeEach(() => test.setup());
 

--- a/test/services/aws_sqs.test.js
+++ b/test/services/aws_sqs.test.js
@@ -8,7 +8,7 @@ TestFixture.prototype.setup = function() {
 };
 
 const test = new TestFixture();
-describe('SQSService', function() {
+describe.skip('SQSService', function() {
   describe('substages', () => {
     beforeEach(() => test.setup());
 

--- a/test/services/http.test.js
+++ b/test/services/http.test.js
@@ -8,7 +8,7 @@ TestFixture.prototype.setup = function() {
 };
 
 const test = new TestFixture();
-describe('HttpService', function() {
+describe.skip('HttpService', function() {
   describe('substages', () => {
     beforeEach(() => test.setup());
 

--- a/test/services/mongodb.test.js
+++ b/test/services/mongodb.test.js
@@ -36,7 +36,7 @@ async function testSetup(fixture) {
 }
 
 let test = new StitchMongoFixture;
-describe('MongoDBService', function() {
+describe.skip('MongoDBService', function() {
   let testService;
   let db;
 

--- a/test/services/pubnub.test.js
+++ b/test/services/pubnub.test.js
@@ -8,7 +8,7 @@ TestFixture.prototype.setup = function() {
 };
 
 const test = new TestFixture();
-describe('PubnubService', function() {
+describe.skip('PubnubService', function() {
   describe('substages', () => {
     beforeEach(() => test.setup());
 

--- a/test/services/slack.test.js
+++ b/test/services/slack.test.js
@@ -8,7 +8,7 @@ TestFixture.prototype.setup = function() {
 };
 
 const test = new TestFixture();
-describe('SlackService', function() {
+describe.skip('SlackService', function() {
   describe('substages', () => {
     beforeEach(() => test.setup());
 

--- a/test/services/twilio.test.js
+++ b/test/services/twilio.test.js
@@ -8,7 +8,7 @@ TestFixture.prototype.setup = function() {
 };
 
 const test = new TestFixture();
-describe('TwilioService', function() {
+describe.skip('TwilioService', function() {
   describe('substages', () => {
     beforeEach(() => test.setup());
 

--- a/test/stitch_client.test.js
+++ b/test/stitch_client.test.js
@@ -7,19 +7,4 @@ describe('StitchClient', () => {
       let service = new client.service('mongodb', 'mdb1');  // eslint-disable-line
     }).toThrow();
   });
-
-  it('should allow a single stage to be passed in to `executePipeline`', () => {
-    const stage = {
-      $pipeline: {
-        name: 'createGroup',
-        args: {
-          groupName: 'dummy'
-        }
-      }
-    };
-
-    let client = new stitch.StitchClient();
-    client._do = () => { return Promise.resolve({ text: () => 'true' }); }; // stub out fetch call
-    return client.executePipeline(stage);
-  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -9,13 +9,11 @@ import { mocks } from 'mock-browser';
 
 const EJSON = require('mongodb-extjson');
 
-const ANON_AUTH_URL = 'https://stitch.mongodb.com/api/client/v1.0/app/testapp/auth/anon/user';
-const APIKEY_AUTH_URL = 'https://stitch.mongodb.com/api/client/v1.0/app/testapp/auth/api/key';
-const LOCALAUTH_URL = 'https://stitch.mongodb.com/api/client/v1.0/app/testapp/auth/local/userpass';
-const PIPELINE_URL = 'https://stitch.mongodb.com/api/client/v1.0/app/testapp/pipeline';
-const FUNCTION_URL = 'https://stitch.mongodb.com/api/client/v1.0/app/testapp/function';
-const NEW_ACCESSTOKEN_URL = 'https://stitch.mongodb.com/api/client/v1.0/app/testapp/auth/newAccessToken';
-const BASEAUTH_URL = 'https://stitch.mongodb.com/api/client/v1.0/app/testapp/auth';
+const ANON_AUTH_URL = 'https://stitch.mongodb.com/api/client/v2.0/app/testapp/auth/providers/anon-user/login';
+const APIKEY_AUTH_URL = 'https://stitch.mongodb.com/api/client/v2.0/app/testapp/auth/providers/api-key/login';
+const LOCALAUTH_URL = 'https://stitch.mongodb.com/api/client/v2.0/app/testapp/auth/providers/local-userpass/login';
+const FUNCTION_CALL_URL = 'https://stitch.mongodb.com/api/client/v2.0/app/testapp/functions/call';
+const SESSION_URL = 'https://stitch.mongodb.com/api/client/v2.0/app/testapp/auth/session';
 const ejson = new EJSON();
 
 const MockBrowser = mocks.MockBrowser;
@@ -85,10 +83,10 @@ describe('Redirect fragment parsing', () => {
     let result = a.parseRedirectFragment(makeFragment({'_stitch_ua': 'somejwt$anotherjwt$userid$deviceid'}), 'state_ABC');
     expect(result.found).toBe(true);
     expect(result.ua).toEqual({
-      accessToken: 'somejwt',
-      refreshToken: 'anotherjwt',
-      userId: 'userid',
-      deviceId: 'deviceid'
+      access_token: 'somejwt',
+      refresh_token: 'anotherjwt',
+      user_id: 'userid',
+      device_id: 'deviceid'
     });
   });
 
@@ -109,8 +107,8 @@ describe('Auth', () => {
     capturedDevice = args.options.device;
     if (validUsernames.indexOf(args.username) >= 0) {
       return {
-        userId: hexStr,
-        deviceId: mockDeviceId,
+        user_id: hexStr,
+        device_id: mockDeviceId,
         device: args.options.device
       };
     }
@@ -134,10 +132,9 @@ describe('Auth', () => {
     describe(envConfig.name, () => { // eslint-disable-line
       beforeEach(() => {
         envConfig.setup();
-        fetchMock.post('/auth/local/userpass', checkLogin);
         fetchMock.post('/auth/providers/local-userpass/login', checkLogin);
-        fetchMock.post(DEFAULT_STITCH_SERVER_URL + '/api/client/v1.0/app/testapp/auth/local/userpass', checkLogin);
-        fetchMock.delete(DEFAULT_STITCH_SERVER_URL + '/api/client/v1.0/app/testapp/auth', {});
+        fetchMock.post(DEFAULT_STITCH_SERVER_URL + '/api/client/v2.0/app/testapp/auth/providers/local-userpass/login', checkLogin);
+        fetchMock.delete(SESSION_URL, {});
         capturedDevice = undefined;
       });
 
@@ -152,9 +149,9 @@ describe('Auth', () => {
         const a = new Auth(null, '/auth');
         expect(a._get()).toEqual({});
 
-        const testUser = {'accessToken': 'bar', 'userId': hexStr};
+        const testUser = {'access_token': 'bar', 'user_id': hexStr};
         a.set(testUser);
-        expect(a._get()).toEqual(testUser);
+        expect(a._get()).toEqual({'accessToken': 'bar', 'userId': hexStr});
         expect(a.authedId()).toEqual(hexStr);
 
         a.clear();
@@ -262,7 +259,7 @@ describe('Auth', () => {
           .then(() => {
             expect(auth.authedId()).toEqual(hexStr);
             expect(auth.getAccessToken()).toBeUndefined();
-            auth.set({'accessToken': 'foo'});
+            auth.set({'access_token': 'foo'});
             expect(auth.getAccessToken()).toEqual('foo');
           });
       });
@@ -285,82 +282,26 @@ describe('Auth', () => {
   }
 });
 
-describe('request metadata', () => {
-  const sampleStages = [{action: 'literal', args: {items: [{x: 5}]}}];
-  describe('warnings in response metadata', () => {
-    beforeEach(()=>{
-      fetchMock.restore();
-      fetchMock.post(LOCALAUTH_URL, {userId: hexStr});
-      fetchMock.post(PIPELINE_URL, (url, opts) => {
-        return { result: [{x: 1}], warnings: [ 'danger will robinson' ] };
-      });
-    });
-
-    it('attaches warnings to response', ()=>{
-      expect.assertions(1);
-      const testClient = new StitchClient('testapp');
-      return testClient.login('user', 'password')
-      .then(() =>
-        testClient.executePipeline(sampleStages)
-      ).then(response => {
-        expect(response._stitch_metadata).toEqual({warnings: ['danger will robinson']});
-      }).catch(
-        err => console.error('error', err)
-      );
-    });
-
-    it('attaches warnings to response with updateOne (no finalizer)', ()=>{
-      expect.assertions(1);
-      const testClient = new StitchClient('testapp');
-      let service = testClient.service('mongodb', 'mdb1');
-      let db = service.db('test');
-      return testClient.login('user', 'password')
-      .then(() =>
-        db.collection('test').updateOne({})
-      ).then(response => {
-        expect(response._stitch_metadata).toEqual({warnings: ['danger will robinson']});
-      }).catch(
-        err => console.error('error', err)
-      );
-    });
-
-    it('attaches warnings to response with find() (finalizer)', ()=>{
-      expect.assertions(1);
-      const testClient = new StitchClient('testapp');
-      let service = testClient.service('mongodb', 'mdb1');
-      let db = service.db('test');
-      return testClient.login('user', 'password')
-      .then(() =>
-        db.collection('test').find({})
-      ).then(response => {
-        expect(response._stitch_metadata).toEqual({warnings: ['danger will robinson']});
-      }).catch(
-        err => console.error('error', err)
-      );
-    });
-  });
-});
-
 describe('http error responses', () => {
   const testErrMsg = 'test: bad request';
   const testErrCode = 'TestBadRequest';
   describe('JSON error responses are handled correctly', () => {
     beforeEach(() => {
       fetchMock.restore();
-      fetchMock.post(PIPELINE_URL, () =>
+      fetchMock.post(FUNCTION_CALL_URL, () =>
         ({
           body: {error: testErrMsg, errorCode: testErrCode},
           headers: { 'Content-Type': JSONTYPE },
           status: 400
         })
       );
-      fetchMock.post(LOCALAUTH_URL, {userId: hexStr});
+      fetchMock.post(LOCALAUTH_URL, {user_id: hexStr});
     });
 
     it('should return a StitchError instance with the error and errorCode extracted', (done) => {
       const testClient = new StitchClient('testapp');
       return testClient.login('user', 'password')
-        .then(() => testClient.executePipeline([{action: 'literal', args: {items: [{x: 5}]}}]))
+        .then(() => testClient.executeFunction('testfunc', {items: [{x: {'oid': hexStr}}]}, 'hello'))
         .catch(e => {
           // This is actually a StitchError, but because there are quirks with
           // transpiling a class that subclasses Error, we can only really
@@ -383,16 +324,16 @@ describe('anonymous auth', () => {
       const device = parsed.query ? parsed.query.device : null;
 
       return {
-        userId: hexStr,
-        deviceId: mockDeviceId,
-        accessToken: 'test-access-token',
-        refreshToken: 'test-refresh-token',
+        user_id: hexStr,
+        device_id: mockDeviceId,
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
         device: device
       };
     });
 
-    fetchMock.post(PIPELINE_URL, (url, opts) => {
-      return {result: [{x: ++count}]};
+    fetchMock.post(FUNCTION_CALL_URL, () => {
+      return JSON.stringify({x: ++count});
     });
   });
 
@@ -404,10 +345,8 @@ describe('anonymous auth', () => {
         expect(testClient.auth.getAccessToken()).toEqual('test-access-token');
         expect(testClient.authedId()).toEqual(hexStr);
       })
-      .then(() => testClient.executePipeline([{action: 'literal', args: {items: [{x: 'foo'}]}}]))
-      .then(response => {
-        expect(response.result[0].x).toEqual(1);
-      });
+      .then(() => testClient.executeFunction('testfunc', {items: [{x: {'oid': hexStr}}]}, 'hello'))
+      .then((response) => expect(response.x).toEqual(1));
   });
 });
 
@@ -419,7 +358,7 @@ describe('api key auth/logout', () => {
     fetchMock.post(APIKEY_AUTH_URL, (url, opts) => {
       if (validAPIKeys.indexOf(JSON.parse(opts.body).key) >= 0) {
         return {
-          userId: hexStr
+          user_id: hexStr
         };
       }
 
@@ -430,8 +369,8 @@ describe('api key auth/logout', () => {
       };
     });
 
-    fetchMock.post(PIPELINE_URL, (url, opts) => {
-      return {result: [{x: ++count}]};
+    fetchMock.post(FUNCTION_CALL_URL, () => {
+      return JSON.stringify({x: ++count});
     });
   });
 
@@ -440,9 +379,9 @@ describe('api key auth/logout', () => {
     let testClient = new StitchClient('testapp');
     return testClient.authenticate('apiKey', 'valid-api-key')
       .then(() => expect(testClient.authedId()).toEqual(hexStr))
-      .then(() => testClient.executePipeline([{action: 'literal', args: {items: [{x: 'foo'}]}}]))
+      .then(() => testClient.executeFunction('testfunc', {items: [{x: 1}]}, 'hello'))
       .then(response => {
-        expect(response.result[0].x).toEqual(1);
+        expect(response.x).toEqual(1);
       });
   });
 
@@ -472,16 +411,16 @@ describe('login/logout', () => {
       beforeEach(() => {
         fetchMock.restore();
         fetchMock.post(LOCALAUTH_URL, {
-          userId: hexStr,
-          refreshToken: testOriginalRefreshToken,
-          accessToken: testOriginalAccessToken
+          user_id: hexStr,
+          refresh_token: testOriginalRefreshToken,
+          access_token: testOriginalAccessToken
         });
 
-        fetchMock.post(PIPELINE_URL, (url, opts) => {
+        fetchMock.post(FUNCTION_CALL_URL, (url, opts) => {
           const providedToken = opts.headers['Authorization'].split(' ')[1];
           if (validAccessTokens.indexOf(providedToken) >= 0) {
             // provided access token is valid
-            return {result: [{x: ++count}]};
+            return {x: ++count};
           }
 
           return {
@@ -491,10 +430,10 @@ describe('login/logout', () => {
           };
         });
 
-        fetchMock.post(NEW_ACCESSTOKEN_URL, (url, opts) => {
+        fetchMock.post(SESSION_URL, (url, opts) => {
           let accessToken = Math.random().toString(36).substring(7);
           validAccessTokens.push(accessToken);
-          return {accessToken};
+          return {access_token: accessToken};
         });
       });
 
@@ -514,18 +453,18 @@ describe('login/logout', () => {
         expect.assertions(4);
         let testClient = new StitchClient('testapp');
         return testClient.login('user', 'password')
-          .then(() => testClient.executePipeline([{action: 'literal', args: {items: [{x: 'foo'}]}}]))
+          .then(() => testClient.executeFunction('testfunc', {items: [{x: 1}]}, 'hello'))
           .then(response => {
             // first request (token is still valid) should yield the response we expect
-            expect(response.result[0].x).toEqual(1);
+            expect(response.x).toEqual(1);
           })
           .then(() => {
             // invalidate the access token. This forces the client to exchange for a new one.
             validAccessTokens = [];
-            return testClient.executePipeline([{action: 'literal', args: {items: [{y: 1000}]}}]);
+            return testClient.executeFunction('testfunc', {items: [{x: 1}]}, 'hello');
           })
           .then(response => {
-            expect(response.result[0].x).toEqual(2);
+            expect(response.x).toEqual(2);
           })
           .then(() => {
             expect(testClient.auth.getAccessToken()).toEqual(validAccessTokens[0]);
@@ -553,11 +492,11 @@ describe('proactive token refresh', () => {
   beforeEach(() => {
     fetchMock.restore();
 
-    fetchMock.post(PIPELINE_URL, (url, opts) => {
+    fetchMock.post(FUNCTION_CALL_URL, (url, opts) => {
       const providedToken = opts.headers['Authorization'].split(' ')[1];
       if (validAccessTokens.indexOf(providedToken) >= 0) {
         // provided access token is valid
-        return {result: [{x: ++count}]};
+        return JSON.stringify({x: ++count});
       }
 
       throw new Error('invalid session would have been returned from server.');
@@ -566,9 +505,9 @@ describe('proactive token refresh', () => {
     count = 0;
     refreshCount = 0;
 
-    fetchMock.post(NEW_ACCESSTOKEN_URL, (url, opts) => {
+    fetchMock.post(SESSION_URL, (url, opts) => {
       ++refreshCount;
-      return {accessToken: testUnexpiredAccessToken};
+      return {access_token: testUnexpiredAccessToken};
     });
   });
 
@@ -576,9 +515,9 @@ describe('proactive token refresh', () => {
     expect.assertions(5);
 
     fetchMock.post(LOCALAUTH_URL, {
-      userId: hexStr,
-      refreshToken: 'refresh-token',
-      accessToken: testExpiredAccessToken
+      user_id: hexStr,
+      refresh_token: 'refresh-token',
+      access_token: testExpiredAccessToken
     });
 
     let testClient = new StitchClient('testapp');
@@ -586,11 +525,11 @@ describe('proactive token refresh', () => {
       .then(() => {
         // make sure we are starting with the expired access token
         expect(testClient.auth.getAccessToken()).toEqual(testExpiredAccessToken);
-        return testClient.executePipeline([{action: 'literal', args: {items: [{x: 'foo'}]}}]);
+        return testClient.executeFunction('testfunc', {items: [{x: 1}]}, 'hello');
       })
       .then(response => {
         // token was expired, though it should yield the response we expect without throwing InvalidSession
-        expect(response.result[0].x).toEqual(1);
+        expect(response.x).toEqual(1);
       })
       .then(() => {
         // make sure token was updated
@@ -607,9 +546,9 @@ describe('proactive token refresh', () => {
     expect.assertions(5);
 
     fetchMock.post(LOCALAUTH_URL, {
-      userId: hexStr,
-      refreshToken: 'refresh-token',
-      accessToken: testUnexpiredAccessToken
+      user_id: hexStr,
+      refresh_token: 'refresh-token',
+      access_token: testUnexpiredAccessToken
     });
 
     let testClient = new StitchClient('testapp');
@@ -617,10 +556,10 @@ describe('proactive token refresh', () => {
       .then(() => {
         // make sure we are starting with the unexpired access token
         expect(testClient.auth.getAccessToken()).toEqual(testUnexpiredAccessToken);
-        return testClient.executePipeline([{action: 'literal', args: {items: [{x: 'foo'}]}}]);
+        return testClient.executeFunction('testfunc', {items: [{x: 1}]}, 'hello');
       })
       .then(response => {
-        expect(response.result[0].x).toEqual(1);
+        expect(response.x).toEqual(1);
       })
       .then(() => {
         // make sure token was not updated
@@ -637,12 +576,14 @@ describe('proactive token refresh', () => {
 describe('client options', () => {
   beforeEach(() => {
     fetchMock.restore();
-    fetchMock.post('https://stitch2.mongodb.com/api/client/v1.0/app/testapp/auth/local/userpass', {userId: hexStr});
-    fetchMock.post('https://stitch2.mongodb.com/api/client/v1.0/app/testapp/pipeline', (url, opts) => {
-      return {result: [{x: {'$oid': hexStr}}]};
+    fetchMock.post('https://stitch2.mongodb.com/api/client/v2.0/app/testapp/auth/providers/local-userpass/login', {user_id: hexStr});
+    fetchMock.post('https://stitch2.mongodb.com/api/client/v2.0/app/testapp/functions/call', (url, opts) => {
+      return {x: {'$oid': hexStr}};
     });
-    fetchMock.delete(BASEAUTH_URL, {});
-    fetchMock.post(PIPELINE_URL, {result: [{x: {'$oid': hexStr}}]});
+    fetchMock.delete(SESSION_URL, {});
+    fetchMock.post(FUNCTION_CALL_URL, () => {
+      return JSON.stringify({x: {'$oid': hexStr}});
+    });
   });
 
   it('allows overriding the base url', () => {
@@ -650,17 +591,17 @@ describe('client options', () => {
     expect.assertions(1);
     return testClient.login('user', 'password')
       .then(() => {
-        return testClient.executePipeline([{action: 'literal', args: {items: [{x: {'$oid': hexStr}}]}}]);
+        return testClient.executeFunction('testfunc', {items: [{x: {'oid': hexStr}}]}, 'hello');
       })
       .then((response) => {
-        expect(response.result[0].x).toEqual(new ejson.bson.ObjectID(hexStr));
+        expect(response.x).toEqual(new ejson.bson.ObjectID(hexStr));
       });
   });
 
   it('returns a rejected promise if trying to execute a pipeline without auth', (done) => {
     let testClient = new StitchClient('testapp');
     testClient.logout()
-      .then(() => testClient.executePipeline([{action: 'literal', args: {items: [{x: {'$oid': hexStr}}]}}]))
+      .then(() => testClient.executeFunction('testfunc', {items: [{x: {'oid': hexStr}}]}, 'hello'))
       .then(() => {
         done(new Error('Error should have been triggered, but was not'));
       })
@@ -668,66 +609,6 @@ describe('client options', () => {
         done();
       });
   });
-});
-
-describe('pipeline execution', () => {
-  for (const envConfig of envConfigs) {
-    describe(envConfig.name, () => {
-      beforeAll(envConfig.setup);
-      afterAll(envConfig.teardown);
-      describe(envConfig.name + ' extended json decode (incoming)', () => {
-        beforeAll(() => {
-          fetchMock.restore();
-          fetchMock.post(LOCALAUTH_URL, {userId: '5899445b275d3ebe8f2ab8a6'});
-          fetchMock.post(PIPELINE_URL, (url, opts) => {
-            let out = JSON.stringify({result: [{x: {'$oid': hexStr}}]});
-            return out;
-          });
-        });
-
-        it('should decode extended json from pipeline responses', () => {
-          expect.assertions(1);
-          let testClient = new StitchClient('testapp');
-          return testClient.login('user', 'password')
-            .then(() =>
-              testClient.executePipeline([{action: 'literal', args: {items: [{x: {'$oid': hexStr}}]}}]))
-            .then((response) => expect(response.result[0].x).toEqual(new ejson.bson.ObjectID(hexStr)));
-        });
-
-        it('should allow overriding the decoder implementation', () => {
-          expect.assertions(1);
-          let testClient = new StitchClient('testapp');
-          return testClient.login('user', 'password')
-            .then(() => testClient.executePipeline([{action: 'literal', args: {items: [{x: {'$oid': hexStr}}]}}], {decoder: JSON.parse}))
-            .then((response) => expect(response.result[0].x).toEqual({'$oid': hexStr}));
-        });
-      });
-
-      describe('extended json encode (outgoing)', () => {
-        let requestOpts;
-        beforeAll(() => {
-          fetchMock.restore();
-          fetchMock.post(LOCALAUTH_URL, {userId: hexStr});
-          fetchMock.post(PIPELINE_URL, (url, opts) => {
-            // TODO there should be a better way to capture request payload for
-            // using in an assertion without doing this.
-            requestOpts = opts;
-            return {result: [{x: {'$oid': hexStr}}]};
-          });
-        });
-
-        it('should encode objects to extended json for outgoing pipeline request body', () => {
-          expect.assertions(1);
-          let requestBodyObj = {action: 'literal', args: {items: [{x: new ejson.bson.ObjectID(hexStr)}]}};
-          let requestBodyExtJSON = {action: 'literal', args: {items: [{x: {'$oid': hexStr}}]}};
-          let testClient = new StitchClient('testapp', {baseUrl: ''});
-          return testClient.login('user', 'password')
-            .then(a => testClient.executePipeline([requestBodyObj]))
-            .then(response => expect(JSON.parse(requestOpts.body)).toEqual([requestBodyExtJSON]));
-        });
-      });
-    });
-  }
 });
 
 describe('function execution', () => {
@@ -738,9 +619,9 @@ describe('function execution', () => {
       describe(envConfig.name + ' extended json decode (incoming)', () => {
         beforeAll(() => {
           fetchMock.restore();
-          fetchMock.post(LOCALAUTH_URL, {userId: '5899445b275d3ebe8f2ab8a6'});
-          fetchMock.post(FUNCTION_URL, () => {
-            return JSON.stringify({result: [{x: {'$oid': hexStr}}]});
+          fetchMock.post(LOCALAUTH_URL, {user_id: '5899445b275d3ebe8f2ab8a6'});
+          fetchMock.post(FUNCTION_CALL_URL, () => {
+            return JSON.stringify({x: {'$oid': hexStr}});
           });
         });
 
@@ -749,7 +630,7 @@ describe('function execution', () => {
           let testClient = new StitchClient('testapp');
           return testClient.login('user', 'password')
             .then(() => testClient.executeFunction('testfunc', {items: [{x: {'oid': hexStr}}]}, 'hello'))
-            .then((response) => expect(response.result[0].x).toEqual(new ejson.bson.ObjectID(hexStr)));
+            .then((response) => expect(response.x).toEqual(new ejson.bson.ObjectID(hexStr)));
         });
       });
 
@@ -757,10 +638,10 @@ describe('function execution', () => {
         let requestArg;
         beforeAll(() => {
           fetchMock.restore();
-          fetchMock.post(LOCALAUTH_URL, {userId: hexStr});
-          fetchMock.post(FUNCTION_URL, (name, arg1) => {
+          fetchMock.post(LOCALAUTH_URL, {user_id: hexStr});
+          fetchMock.post(FUNCTION_CALL_URL, (name, arg1) => {
             requestArg = arg1;
-            return {result: [{x: {'$oid': hexStr}}]};
+            return {x: {'$oid': hexStr}};
           });
         });
 
@@ -776,8 +657,8 @@ describe('function execution', () => {
       describe('non 2xx is returned', () => {
         beforeAll(() => {
           fetchMock.restore();
-          fetchMock.post(LOCALAUTH_URL, {userId: hexStr});
-          fetchMock.post(FUNCTION_URL, (name, arg1, arg2) => {
+          fetchMock.post(LOCALAUTH_URL, {user_id: hexStr});
+          fetchMock.post(FUNCTION_CALL_URL, (name, arg1, arg2) => {
             return {
               body: {error: 'bad request'},
               headers: { 'Content-Type': JSONTYPE },


### PR DESCRIPTION
@UnicodeSnowman see for reference of why certain changes were made: https://github.com/10gen/stitch/pull/352

Basically, removed some v1 stuff but not all of it. Skipping tests for pipelines since the client no longer knows much about them.