### PR TITLE
STITCH-880 - Add admin v3.0 and remove admin v1.0/v2.0

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -5,7 +5,6 @@ import StitchClient from './client';
 import ADMIN_CLIENT_TYPE from './common';
 import { ADMIN_CLIENT_CODEC } from './auth/common';
 
-const v1 = 1;
 const v2 = 2;
 const v3 = 3;
 
@@ -23,7 +22,7 @@ export default class Admin extends StitchClient {
       super._do(
         url,
         method,
-        Object.assign({}, {apiVersion: v3}, options)
+        Object.assign({}, { apiVersion: v3 }, options)
       ).then(response => {
         const contentHeader = response.headers.get('content-type') || '';
         if (contentHeader.split(',').indexOf('application/json') >= 0) {
@@ -55,7 +54,7 @@ export default class Admin extends StitchClient {
       super._do(
         url,
         method,
-        Object.assign({}, {apiVersion: v2}, options)
+        Object.assign({}, { apiVersion: v2 }, options)
       ).then(response => {
         const contentHeader = response.headers.get('content-type') || '';
         if (contentHeader.split(',').indexOf('application/json') >= 0) {
@@ -63,6 +62,7 @@ export default class Admin extends StitchClient {
         }
         return response;
       });
+
     return {
       _get: (url, queryParams) => v2do(url, 'GET', {queryParams}),
       _put: (url, data) =>
@@ -81,76 +81,13 @@ export default class Admin extends StitchClient {
     };
   }
 
-  get _v3() {
-    const v3do = (url, method, options) =>
-       super._do(
-         url,
-         method,
-         Object.assign({}, {apiVersion: v3}, options)
-       ).then(response => {
-         const contentHeader = response.headers.get('content-type') || '';
-         if (contentHeader.split(',').indexOf('application/json') >= 0) {
-           return response.json();
-         }
-         return response;
-       });
-
-    return {
-      _get: (url, queryParams) => v3do(url, 'GET', {queryParams}),
-      _put: (url, data) =>
-         (data ?
-           v3do(url, 'PUT', {body: JSON.stringify(data)}) :
-           v3do(url, 'PUT')),
-      _patch: (url, data) =>
-         (data ?
-           v3do(url, 'PATCH', {body: JSON.stringify(data)}) :
-           v3do(url, 'PATCH')),
-      _delete: (url)  => v3do(url, 'DELETE'),
-      _post: (url, body, queryParams) =>
-         (queryParams ?
-           v3do(url, 'POST', { body: JSON.stringify(body), queryParams }) :
-           v3do(url, 'POST', { body: JSON.stringify(body) }))
-    };
-  }
-
-  get _v1() {
-    const v1do = (url, method, options) =>
-      super._do(
-        url,
-        method,
-        Object.assign({}, {apiVersion: v1}, options)
-      ).then(response => response.json());
-    return {
-      _get: (url, queryParams) => v1do(url, 'GET', {queryParams}),
-      _put: (url, options) => v1do(url, 'PUT', options),
-      _delete: (url)  => v1do(url, 'DELETE'),
-      _post: (url, body) => v1do(url, 'POST', {body: JSON.stringify(body)})
-    };
-  }
-
-  profile() {
-    const api = this._v1;
-    return {
-      keys: () => ({
-        list: () => api._get('/profile/keys'),
-        create: (key) => api._post('/profile/keys'),
-        apiKey: (keyId) => ({
-          get: () => api._get(`/profile/keys/${keyId}`),
-          remove: () => api._delete(`/profile/keys/${keyId}`),
-          enable: () => api._put(`/profile/keys/${keyId}/enable`),
-          disable: () => api._put(`/profile/keys/${keyId}/disable`)
-        })
-      })
-    };
-  }
-
   /**
    * Ends the session for the current user.
    *
    * @returns {Promise}
    */
   logout() {
-    return super._do('/auth/session', 'DELETE', { refreshOnFailure: false, useRefreshToken: true, apiVersion: v2 })
+    return super._do('/auth/session', 'DELETE', { refreshOnFailure: false, useRefreshToken: true, apiVersion: v3 })
       .then(() => this.auth.clear());
   }
 
@@ -160,7 +97,7 @@ export default class Admin extends StitchClient {
    * @returns {Promise}
    */
   userProfile() {
-    return this._v2._get('/auth/profile');
+    return this._v3._get('/auth/profile');
   }
 
   /**
@@ -169,7 +106,7 @@ export default class Admin extends StitchClient {
    * @returns {Promise}
    */
   getAuthProviders() {
-    return super._do('/auth/providers', 'GET', { noAuth: true, apiVersion: v2 })
+    return super._do('/auth/providers', 'GET', { noAuth: true, apiVersion: v3 })
       .then(response => response.json());
   }
 
@@ -179,7 +116,7 @@ export default class Admin extends StitchClient {
    * @returns {Promise}
    */
   doSessionPost() {
-    return super._do('/auth/session', 'POST', { refreshOnFailure: false, useRefreshToken: true, apiVersion: v2 })
+    return super._do('/auth/session', 'POST', { refreshOnFailure: false, useRefreshToken: true, apiVersion: v3 })
       .then(response => response.json());
   }
 
@@ -199,137 +136,155 @@ export default class Admin extends StitchClient {
    *
    */
   apps(groupId) {
-    const api = this._v1;
+    const api = this._v3;
+    const groupUrl = `/groups/${groupId}/apps`;
     return {
-      list: () => api._get(`/groups/${groupId}/apps`),
+      list: () => api._get(groupUrl),
       create: (data, options) => {
         let query = (options && options.defaults) ? '?defaults=true' : '';
-        return api._post(`/groups/${groupId}/apps` + query, data);
+        return api._post(groupUrl + query, data);
       },
 
-      app: (appID) => ({
-        get: () => api._get(`/groups/${groupId}/apps/${appID}`),
-        remove: () => api._delete(`/groups/${groupId}/apps/${appID}`),
-        replace: (doc) => api._put(`/groups/${groupId}/apps/${appID}`, {
-          headers: { 'X-Stitch-Unsafe': appID },
-          body: JSON.stringify(doc)
-        }),
+      app: (appId) => {
+        const appUrl = `${groupUrl}/${appId}`;
+        return {
+          get: () => api._get(appUrl),
+          remove: () => api._delete(appUrl),
 
-        messages: () => ({
-          list: (filter) =>  api._get(`/groups/${groupId}/apps/${appID}/push/messages`, filter),
-          create: (msg) =>  api._put(`/groups/${groupId}/apps/${appID}/push/messages`,  {body: JSON.stringify(msg)}),
-          message: (id) => ({
-            get: () => api._get(`/groups/${groupId}/apps/${appID}/push/messages/${id}`),
-            remove: () => api._delete(`/groups/${groupId}/apps/${appID}/push/messages/${id}`),
-            setSaveType: type => api._post(`/groups/${groupId}/apps/${appID}/push/messages/${id}`, {type}),
-            update: msg => api._put(`/groups/${groupId}/apps/${appID}/push/messages/${id}`, {body: JSON.stringify(msg)})
-          })
-        }),
+          values: () => ({
+            list: () => api._get(`${appUrl}/values`),
+            create: (data) => api._post( `${appUrl}/values`, data),
+            value: (valueId) => {
+              const valueUrl = `${appUrl}/values/${valueId}`;
+              return {
+                get: ()=> api._get(valueUrl),
+                remove: ()=> api._delete(valueUrl),
+                update: (data) => api._put(valueUrl, data)
+              };
+            }
+          }),
 
-        users: () => ({
-          list: (filter) => api._get(`/groups/${groupId}/apps/${appID}/users`, filter),
-          create: (user) => api._post(`/groups/${groupId}/apps/${appID}/users`, user),
-          user: (uid) => ({
-            get: () => api._get(`/groups/${groupId}/apps/${appID}/users/${uid}`),
-            logout: () => api._put(`/groups/${groupId}/apps/${appID}/users/${uid}/logout`),
-            remove: () => api._delete(`/groups/${groupId}/apps/${appID}/users/${uid}`)
-          })
-        }),
+          services: () => ({
+            list: () => api._get(`${appUrl}/services`),
+            create: (data) => api._post(`${appUrl}/services`, data),
+            service: (serviceId) => ({
+              get: () => api._get(`${appUrl}/services/${serviceId}`),
+              remove: () => api._delete(`${appUrl}/services/${serviceId}`),
+              config: ()=> ({
+                get: () => api._get(`${appUrl}/services/${serviceId}/config`),
+                update: (data) => api._patch(`${appUrl}/services/${serviceId}/config`, data)
+              }),
 
-        sandbox: () => ({
-          executePipeline: (data, userId, options) => {
-            const queryParams = Object.assign({}, options, {user_id: userId});
-            return super._do(
-              `/groups/${groupId}/apps/${appID}/sandbox/pipeline`,
-              'POST',
-              {body: JSON.stringify(data), queryParams, apiVersion: v1});
-          }
-        }),
+              rules: () => ({
+                list: () => api._get(`${appUrl}/services/${serviceId}/rules`),
+                create: (data) => api._post(`${appUrl}/services/${serviceId}/rules`, data),
+                rule: (ruleId) => {
+                  const ruleUrl = `${appUrl}/services/${serviceId}/rules/${ruleId}`;
+                  return {
+                    get: () => api._get(ruleUrl),
+                    update: (data) => api._put(ruleUrl, data),
+                    remove: () => api._delete(ruleUrl)
+                  };
+                }
+              }),
 
-        authProviders: () => ({
-          create: (data) => api._post(`/groups/${groupId}/apps/${appID}/authProviders`, data),
-          list: () => api._get(`/groups/${groupId}/apps/${appID}/authProviders`),
-          provider: (authType, authName) => ({
-            get: () => api._get(`/groups/${groupId}/apps/${appID}/authProviders/${authType}/${authName}`),
-            remove: () => api._delete(`/groups/${groupId}/apps/${appID}/authProviders/${authType}/${authName}`),
-            update: (data) => api._post(`/groups/${groupId}/apps/${appID}/authProviders/${authType}/${authName}`, data)
-          })
-        }),
-        security: () => ({
-          allowedRequestOrigins: () => ({
-            get: () => api._get(`/groups/${groupId}/apps/${appID}/security/allowedRequestOrigins`),
-            update: (data) => api._post(`/groups/${groupId}/apps/${appID}/security/allowedRequestOrigins`, data)
-          })
-        }),
-        values: () => ({
-          list: () => api._get(`/groups/${groupId}/apps/${appID}/values`),
-          value: (varName) => ({
-            get: () => api._get(`/groups/${groupId}/apps/${appID}/values/${varName}`),
-            remove: () => api._delete(`/groups/${groupId}/apps/${appID}/values/${varName}`),
-            create: (data) => api._post(`/groups/${groupId}/apps/${appID}/values/${varName}`, data),
-            update: (data) => api._post(`/groups/${groupId}/apps/${appID}/values/${varName}`, data)
-          })
-        }),
-        pipelines: () => ({
-          list: () => api._get(`/groups/${groupId}/apps/${appID}/pipelines`),
-          pipeline: (varName) => ({
-            get: () => api._get(`/groups/${groupId}/apps/${appID}/pipelines/${varName}`),
-            remove: () => api._delete(`/groups/${groupId}/apps/${appID}/pipelines/${varName}`),
-            create: (data) => api._post(`/groups/${groupId}/apps/${appID}/pipelines/${varName}`, data),
-            update: (data) => api._post(`/groups/${groupId}/apps/${appID}/pipelines/${varName}`, data)
-          })
-        }),
-        logs: () => ({
-          get: (filter) => api._get(`/groups/${groupId}/apps/${appID}/logs`, filter)
-        }),
-        apiKeys: () => ({
-          list: () => api._get(`/groups/${groupId}/apps/${appID}/keys`),
-          create: (data) => api._post(`/groups/${groupId}/apps/${appID}/keys`, data),
-          apiKey: (key) => ({
-            get: () => api._get(`/groups/${groupId}/apps/${appID}/keys/${key}`),
-            remove: () => api._delete(`/groups/${groupId}/apps/${appID}/keys/${key}`),
-            enable: () => api._put(`/groups/${groupId}/apps/${appID}/keys/${key}/enable`),
-            disable: () => api._put(`/groups/${groupId}/apps/${appID}/keys/${key}/disable`)
-          })
-        }),
-        services: () => ({
-          list: () => api._get(`/groups/${groupId}/apps/${appID}/services`),
-          create: (data) => api._post(`/groups/${groupId}/apps/${appID}/services`, data),
-          service: (svc) => ({
-            get: () => api._get(`/groups/${groupId}/apps/${appID}/services/${svc}`),
-            update: (data) => api._post(`/groups/${groupId}/apps/${appID}/services/${svc}`, data),
-            remove: () => api._delete(`/groups/${groupId}/apps/${appID}/services/${svc}`),
-            setConfig: (data) => api._post(`/groups/${groupId}/apps/${appID}/services/${svc}/config`, data),
-
-            rules: () => ({
-              list: () => api._get(`/groups/${groupId}/apps/${appID}/services/${svc}/rules`),
-              create: (data) => api._post(`/groups/${groupId}/apps/${appID}/services/${svc}/rules`),
-              rule: (ruleId) => ({
-                get: () => api._get(`/groups/${groupId}/apps/${appID}/services/${svc}/rules/${ruleId}`),
-                update: (data) => api._post(`/groups/${groupId}/apps/${appID}/services/${svc}/rules/${ruleId}`, data),
-                remove: () => api._delete(`/groups/${groupId}/apps/${appID}/services/${svc}/rules/${ruleId}`)
-              })
-            }),
-
-            incomingWebhooks: () => ({
-              list: () => api._get(`/groups/${groupId}/apps/${appID}/services/${svc}/incomingWebhooks`),
-              create: (data) => api._post(`/groups/${groupId}/apps/${appID}/services/${svc}/incomingWebhooks`, data),
-              incomingWebhook: (incomingWebhookId) => ({
-                get: () => api._get(`/groups/${groupId}/apps/${appID}/services/${svc}/incomingWebhooks/${incomingWebhookId}`),
-                update: (data) => api._post(`/groups/${groupId}/apps/${appID}/services/${svc}/incomingWebhooks/${incomingWebhookId}`, data),
-                remove: () => api._delete(`/groups/${groupId}/apps/${appID}/services/${svc}/incomingWebhooks/${incomingWebhookId}`)
+              incomingWebhooks: () => ({
+                list: () => api._get(`${appUrl}/services/${serviceId}/incoming_webhooks`),
+                create: (data) => api._post(`${appUrl}/services/${serviceId}/incoming_webhooks`, data),
+                incomingWebhook: (incomingWebhookId) => {
+                  const webhookUrl = `${appUrl}/services/${serviceId}/incoming_webhooks/${incomingWebhookId}`;
+                  return {
+                    get: () => api._get(webhookUrl),
+                    update: (data) => api._put(webhookUrl, data),
+                    remove: () => api._delete(webhookUrl)
+                  };
+                }
               })
             })
+          }),
+
+          pushNotifications: () => ({
+            list: (filter) => api._get(`${appUrl}/push/notifications`, filter),
+            create: (data) => api._post(`${appUrl}/push/notifications`, data),
+            pushNotification: (messageId) => ({
+              get: () => api._get(`${appUrl}/push/notifications/${messageId}`),
+              update: (data) => api._put(`${appUrl}/push/notifications/${messageId}`, data),
+              setType: (type) => api._put(`${appUrl}/push/notifications/${messageId}/type`, { type }),
+              remove: () => api._delete(`${appUrl}/push/notifications/${messageId}`)
+            })
+          }),
+
+          users: () => ({
+            list: (filter) => api._get(`${appUrl}/users`, filter),
+            create: (user) => api._post(`${appUrl}/users`, user),
+            user: (uid) => ({
+              get: () => api._get(`${appUrl}/users/${uid}`),
+              logout: () => api._put(`${appUrl}/users/${uid}/logout`),
+              remove: () => api._delete(`${appUrl}/users/${uid}`)
+            })
+          }),
+
+          dev: () => ({
+            executeFunction: (userId, name = '', ...args) => {
+              return api._post(
+                `${appUrl}/dev/function`,
+                {name, 'arguments': args},
+                { user_id: userId });
+            }
+          }),
+
+          authProviders: () => ({
+            list: () => api._get(`${appUrl}/auth_providers`),
+            create: (data) => api._post(`${appUrl}/auth_providers`, data),
+            authProvider: (providerId) => ({
+              get: () => api._get(`${appUrl}/auth_providers/${providerId}`),
+              update: (data) => api._patch(`${appUrl}/auth_providers/${providerId}`, data),
+              enable: () => api._put(`${appUrl}/auth_providers/${providerId}/enable`),
+              disable: () => api._put(`${appUrl}/auth_providers/${providerId}/disable`),
+              remove: () => api._delete(`${appUrl}/auth_providers/${providerId}`)
+            })
+          }),
+
+          security: () => ({
+            allowedRequestOrigins: () => ({
+              get: () => api._get(`${appUrl}/security/allowed_request_origins`),
+              update: (data) => api._post(`${appUrl}/security/allowed_request_origins`, data)
+            })
+          }),
+
+          logs: () => ({
+            list: (filter) => api._get(`${appUrl}/logs`, filter)
+          }),
+
+          apiKeys: () => ({
+            list: () => api._get(`${appUrl}/api_keys`),
+            create: (data) => api._post(`${appUrl}/api_keys`, data),
+            apiKey: (apiKeyId) => ({
+              get: () => api._get(`${appUrl}/api_keys/${apiKeyId}`),
+              remove: () => api._delete(`${appUrl}/api_keys/${apiKeyId}`),
+              enable: () => api._put(`${appUrl}/api_keys/${apiKeyId}/enable`),
+              disable: () => api._put(`${appUrl}/api_keys/${apiKeyId}/disable`)
+            })
+          }),
+
+          functions: () => ({
+            list: () => api._get(`${appUrl}/functions`),
+            create: (data) => api._post(`${appUrl}/functions`, data),
+            function: (functionId) => ({
+              get: () => api._get(`${appUrl}/functions/${functionId}`),
+              update: (data) => api._put(`${appUrl}/functions/${functionId}`, data),
+              remove: () => api._delete(`${appUrl}/functions/${functionId}`)
+            })
           })
-        })
-      })
+        };
+      }
     };
   }
 
   v2() {
     const api = this._v2;
-    const apiV3 = this._v3; // exists solely for function endpoints
     return {
+
       apps: (groupId)  => {
         const groupUrl = `/groups/${groupId}/apps`;
         return {
@@ -338,11 +293,13 @@ export default class Admin extends StitchClient {
             let query = (options && options.defaults) ? '?defaults=true' : '';
             return api._post(groupUrl + query, data);
           },
+
           app: (appId) => {
             const appUrl = `${groupUrl}/${appId}`;
             return {
               get: () => api._get(appUrl),
               remove: () => api._delete(appUrl),
+
               pipelines: () => ({
                 list: () => api._get(`${appUrl}/pipelines`),
                 create: (data) => api._post( `${appUrl}/pipelines`, data),
@@ -355,6 +312,7 @@ export default class Admin extends StitchClient {
                   };
                 }
               }),
+
               values: () => ({
                 list: () => api._get(`${appUrl}/values`),
                 create: (data) => api._post( `${appUrl}/values`, data),
@@ -367,12 +325,14 @@ export default class Admin extends StitchClient {
                   };
                 }
               }),
+
               services: () => ({
                 list: () => api._get(`${appUrl}/services`),
                 create: (data) => api._post(`${appUrl}/services`, data),
                 service: (serviceId) => ({
                   get: () => api._get(`${appUrl}/services/${serviceId}`),
                   remove: () => api._delete(`${appUrl}/services/${serviceId}`),
+
                   config: ()=> ({
                     get: () => api._get(`${appUrl}/services/${serviceId}/config`),
                     update: (data) => api._patch(`${appUrl}/services/${serviceId}/config`, data)
@@ -406,6 +366,7 @@ export default class Admin extends StitchClient {
 
                 })
               }),
+
               pushNotifications: () => ({
                 list: (filter) => api._get(`${appUrl}/push/notifications`, filter),
                 create: (data) => api._post(`${appUrl}/push/notifications`, data),
@@ -416,6 +377,7 @@ export default class Admin extends StitchClient {
                   remove: () => api._delete(`${appUrl}/push/notifications/${messageId}`)
                 })
               }),
+
               users: () => ({
                 list: (filter) => api._get(`${appUrl}/users`, filter),
                 create: (user) => api._post(`${appUrl}/users`, user),
@@ -425,20 +387,16 @@ export default class Admin extends StitchClient {
                   remove: () => api._delete(`${appUrl}/users/${uid}`)
                 })
               }),
+
               dev: () => ({
                 executePipeline: (body, userId, options) => {
                   return api._post(
                     `${appUrl}/dev/pipeline`,
                     body,
                     Object.assign({}, options, { user_id: userId }));
-                },
-                executeFunction: (userId, name = '', ...args) => {
-                  return apiV3._post(
-                    `${appUrl}/dev/function`,
-                    {name, 'arguments': args},
-                    { user_id: userId });
                 }
               }),
+
               authProviders: () => ({
                 list: () => api._get(`${appUrl}/auth_providers`),
                 create: (data) => api._post(`${appUrl}/auth_providers`, data),
@@ -450,15 +408,18 @@ export default class Admin extends StitchClient {
                   remove: () => api._delete(`${appUrl}/auth_providers/${providerId}`)
                 })
               }),
+
               security: () => ({
                 allowedRequestOrigins: () => ({
                   get: () => api._get(`${appUrl}/security/allowed_request_origins`),
                   update: (data) => api._post(`${appUrl}/security/allowed_request_origins`, data)
                 })
               }),
+
               logs: () => ({
                 list: (filter) => api._get(`${appUrl}/logs`, filter)
               }),
+
               apiKeys: () => ({
                 list: () => api._get(`${appUrl}/api_keys`),
                 create: (data) => api._post(`${appUrl}/api_keys`, data),
@@ -467,17 +428,6 @@ export default class Admin extends StitchClient {
                   remove: () => api._delete(`${appUrl}/api_keys/${apiKeyId}`),
                   enable: () => api._put(`${appUrl}/api_keys/${apiKeyId}/enable`),
                   disable: () => api._put(`${appUrl}/api_keys/${apiKeyId}/disable`)
-                })
-              }),
-              // Function endpoints are the only endpoints that are different between v2 and v3
-              // Take note that this branch leverages `apiV3` for hitting function endpoints
-              functions: () => ({
-                list: () => apiV3._get(`${appUrl}/functions`),
-                create: (data) => apiV3._post(`${appUrl}/functions`, data),
-                function: (functionId) => ({
-                  get: () => apiV3._get(`${appUrl}/functions/${functionId}`),
-                  update: (data) => apiV3._put(`${appUrl}/functions/${functionId}`, data),
-                  remove: () => apiV3._delete(`${appUrl}/functions/${functionId}`)
                 })
               })
             };

--- a/test/admin/api_keys.test.js
+++ b/test/admin/api_keys.test.js
@@ -2,7 +2,7 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
 import { getAuthenticatedClient } from '../testutil';
 
-describe('API Keys V2', () => {
+describe('API Keys', () => {
   let test = new StitchMongoFixture();
   let apiKeys;
   let app;
@@ -12,23 +12,20 @@ describe('API Keys V2', () => {
   beforeEach(async () => {
     let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
     test.groupId = test.userData.group.groupId;
-    apps = await adminClient.v2().apps(test.groupId);
+    apps = await adminClient.apps(test.groupId);
     app = await apps.create({ name: 'testname' });
     apiKeys = adminClient
-      .v2()
       .apps(test.groupId)
       .app(app._id)
       .apiKeys();
 
     // enable api key auth provider
     let providers = await adminClient
-      .v2()
       .apps(test.groupId)
       .app(app._id)
       .authProviders()
       .list();
     await adminClient
-      .v2()
       .apps(test.groupId)
       .app(app._id)
       .authProviders()

--- a/test/admin/app.test.js
+++ b/test/admin/app.test.js
@@ -1,43 +1,42 @@
 const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 import {getAuthenticatedClient} from '../testutil';
 
-describe('Apps V2', ()=>{
+describe('Apps', ()=>{
   let test = new StitchMongoFixture();
-  let apiV2;
+  let adminClient;
   beforeAll(() => test.setup());
   afterAll(() => test.teardown());
   beforeEach(async () =>{
-    let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
+    adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
     test.groupId = test.userData.group.groupId;
-    apiV2 = adminClient.v2();
   });
 
   it('listing apps should return empty list', async () => {
-    let apps = await apiV2.apps(test.groupId).list();
+    let apps = await adminClient.apps(test.groupId).list();
     expect(apps).toEqual([]);
   });
 
   const testAppName = 'testapp';
   it('can create an app successfully', async () => {
-    const app = await apiV2.apps(test.groupId).create({name: testAppName});
+    const app = await adminClient.apps(test.groupId).create({name: testAppName});
     expect(app).toBeDefined();
     expect(app.name).toEqual(testAppName);
   });
   it('newly created app should appear in list', async () => {
-    const app = await apiV2.apps(test.groupId).create({name: testAppName});
-    const apps = (await apiV2.apps(test.groupId).list()).filter(x => x._id === app._id);
+    const app = await adminClient.apps(test.groupId).create({name: testAppName});
+    const apps = (await adminClient.apps(test.groupId).list()).filter(x => x._id === app._id);
     expect(apps).toHaveLength(1);
     expect(apps[0]).toEqual(app);
   });
   it('can fetch an existing app', async () => {
-    const app = await apiV2.apps(test.groupId).create({name: testAppName});
-    const appFetched = await apiV2.apps(test.groupId).app(app._id).get();
+    const app = await adminClient.apps(test.groupId).create({name: testAppName});
+    const appFetched = await adminClient.apps(test.groupId).app(app._id).get();
     expect(app).toEqual(appFetched);
   });
   it('can delete an app', async () => {
-    let app = await apiV2.apps(test.groupId).create({name: testAppName});
-    await apiV2.apps(test.groupId).app(app._id).remove();
-    const apps = (await apiV2.apps(test.groupId).list()).filter(x => x._id === app._id);
+    let app = await adminClient.apps(test.groupId).create({name: testAppName});
+    await adminClient.apps(test.groupId).app(app._id).remove();
+    const apps = (await adminClient.apps(test.groupId).list()).filter(x => x._id === app._id);
     expect(apps).toHaveLength(0);
   });
 });

--- a/test/admin/authProviders.test.js
+++ b/test/admin/authProviders.test.js
@@ -2,7 +2,7 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
 import {getAuthenticatedClient} from '../testutil';
 
-describe('Auth Providers V2', ()=>{
+describe('Auth Providers', ()=>{
   let test = new StitchMongoFixture();
   let authProviders;
   let app;
@@ -18,9 +18,9 @@ describe('Auth Providers V2', ()=>{
   beforeEach(async () =>{
     let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
     test.groupId = test.userData.group.groupId;
-    apps = await adminClient.v2().apps(test.groupId);
+    apps = await adminClient.apps(test.groupId);
     app = await apps.create({name: 'testname'});
-    authProviders = adminClient.v2().apps(test.groupId).app(app._id).authProviders();
+    authProviders = adminClient.apps(test.groupId).app(app._id).authProviders();
   });
   afterEach(async () => {
     await apps.app(app._id).remove();

--- a/test/admin/dev.test.js
+++ b/test/admin/dev.test.js
@@ -2,6 +2,81 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
 import { getAuthenticatedClient } from '../testutil';
 
+async function createAppUser(users, { email = 'dude.mcgee@doofus.net', password = 'doofus123' } = {}) {
+  const user = await users.create({ email, password });
+  expect(user.data.email).toEqual(email);
+  return user;
+}
+
+async function createUserPassProvider(authProviders) {
+  const provider = await authProviders.create({
+    type: 'local-userpass',
+    config: {
+      emailConfirmationUrl: 'http://emailConfirmURL.com',
+      resetPasswordUrl: 'http://resetPasswordURL.com',
+      confirmEmailSubject: 'email subject',
+      resetPasswordSubject: 'password subject'
+    }
+  });
+  expect(provider.type).toEqual('local-userpass');
+  return provider;
+}
+
+const FUNC_NAME = 'myFunction';
+const FUNC_SOURCE = 'exports = function(arg1, arg2){ return {sum: arg1 + arg2, userId: context.user.id}}';
+
+async function createTestFunction(functions) {
+  let func = await functions.create({ name: FUNC_NAME, source: FUNC_SOURCE });
+  expect(func.name).toEqual(FUNC_NAME);
+
+  let funcs = await functions.list();
+  expect(funcs).toHaveLength(1);
+  expect(funcs[0].name).toEqual(FUNC_NAME);
+}
+
+describe('Dev Function', () => {
+  let test = new StitchMongoFixture();
+  let apps;
+  let app;
+  let user;
+  let dev;
+
+  beforeAll(() => test.setup());
+  afterAll(() => test.teardown());
+
+  beforeEach(async () => {
+    let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
+    test.groupId = test.userData.group.groupId;
+    apps = await adminClient.apps(test.groupId);
+    app = await apps.create({ name: 'testname' });
+    dev = adminClient.apps(test.groupId).app(app._id).dev();
+
+    await createTestFunction(adminClient.apps(test.groupId).app(app._id).functions());
+    await createUserPassProvider(adminClient.apps(test.groupId).app(app._id).authProviders());
+    user = await createAppUser(adminClient.apps(test.groupId).app(app._id).users());
+  });
+
+  afterEach(async () => {
+    await apps.app(app._id).remove();
+  });
+
+  it('Supports executing the function', async () => {
+    const result = await dev.executeFunction(
+      user._id,
+      FUNC_NAME,
+      777,
+      23,
+    );
+
+    expect(result.result.sum).toEqual({'$numberInt': '800'});
+    expect(result.result.userId).toEqual(user._id);
+  });
+});
+
+// the below test is only supported in the deprecated v2 api
+// once the ability to query for both named pipelines and incoming webhooks with pipelines
+// is no longer needed, this can be removed.
+
 async function createTestPipeline(appPipelines) {
   const pipelineName = 'testPipelineName';
   const testPipeline = {
@@ -30,27 +105,7 @@ async function createTestPipeline(appPipelines) {
   expect(pipelines).toHaveLength(1);
 }
 
-async function createAppUser(users, { email = 'dude.mcgee@doofus.net', password = 'doofus123' } = {}) {
-  const user = await users.create({ email, password });
-  expect(user.data.email).toEqual(email);
-  return user;
-}
-
-async function createUserPassProvider(authProviders) {
-  const provider = await authProviders.create({
-    type: 'local-userpass',
-    config: {
-      emailConfirmationUrl: 'http://emailConfirmURL.com',
-      resetPasswordUrl: 'http://resetPasswordURL.com',
-      confirmEmailSubject: 'email subject',
-      resetPasswordSubject: 'password subject'
-    }
-  });
-  expect(provider.type).toEqual('local-userpass');
-  return provider;
-}
-
-describe('Dev V2', () => {
+describe('Dev Pipeline (V2)', () => {
   let test = new StitchMongoFixture();
   let apps;
   let app;
@@ -95,56 +150,5 @@ describe('Dev V2', () => {
         { '$numberInt': '2' },
         { '$numberInt': '3' }
     ]);
-  });
-});
-
-const FUNC_NAME = 'myFunction';
-const FUNC_SOURCE = 'exports = function(arg1, arg2){ return {sum: arg1 + arg2, userId: context.user.id}}';
-
-async function createTestFunction(functions) {
-  let func = await functions.create({ name: FUNC_NAME, source: FUNC_SOURCE });
-  expect(func.name).toEqual(FUNC_NAME);
-
-  let funcs = await functions.list();
-  expect(funcs).toHaveLength(1);
-  expect(funcs[0].name).toEqual(FUNC_NAME);
-}
-
-describe('Dev Function', () => {
-  let test = new StitchMongoFixture();
-  let apps;
-  let app;
-  let user;
-  let dev;
-
-  beforeAll(() => test.setup());
-  afterAll(() => test.teardown());
-
-  beforeEach(async () => {
-    let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
-    test.groupId = test.userData.group.groupId;
-    apps = await adminClient.v2().apps(test.groupId);
-    app = await apps.create({ name: 'testname' });
-    dev = adminClient.v2().apps(test.groupId).app(app._id).dev();
-
-    await createTestFunction(adminClient.v2().apps(test.groupId).app(app._id).functions());
-    await createUserPassProvider(adminClient.v2().apps(test.groupId).app(app._id).authProviders());
-    user = await createAppUser(adminClient.v2().apps(test.groupId).app(app._id).users());
-  });
-
-  afterEach(async () => {
-    await apps.app(app._id).remove();
-  });
-
-  it('Supports executing the function', async () => {
-    const result = await dev.executeFunction(
-      user._id,
-      FUNC_NAME,
-      777,
-      23,
-    );
-
-    expect(result.result.sum).toEqual({'$numberInt': '800'});
-    expect(result.result.userId).toEqual(user._id);
   });
 });

--- a/test/admin/functions.test.js
+++ b/test/admin/functions.test.js
@@ -2,7 +2,7 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
 import { getAuthenticatedClient } from '../testutil';
 
-describe('Functions V3', () => {
+describe('Functions', () => {
   let test = new StitchMongoFixture();
   let functions;
   let app;
@@ -12,10 +12,9 @@ describe('Functions V3', () => {
   beforeEach(async () => {
     let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
     test.groupId = test.userData.group.groupId;
-    apps = await adminClient.v2().apps(test.groupId);
+    apps = await adminClient.apps(test.groupId);
     app = await apps.create({ name: 'testname' });
     functions = adminClient
-      .v2()
       .apps(test.groupId)
       .app(app._id)
       .functions();
@@ -25,11 +24,11 @@ describe('Functions V3', () => {
   });
 
   const FUNC_NAME = 'myFunction';
-  const FUNC_SOURCE = 'return "hello world!";';
+  const FUNC_SOURCE = 'exports = function(){ return "hello world!"; }';
   const createTestFunction = () => ({ name: FUNC_NAME, source: FUNC_SOURCE });
 
   const FUNC_UPDATED_NAME = 'myFunction';
-  const FUNC_UPDATED_SOURCE = 'return "!dlrow olleh";';
+  const FUNC_UPDATED_SOURCE = 'exports = function(){ return "!dlrow olleh"; }';
   const createUpdatedFunction = () => ({ name: FUNC_UPDATED_NAME, source: FUNC_UPDATED_SOURCE });
 
   it('listing functions should return an empty list', async () => {

--- a/test/admin/logs.test.js
+++ b/test/admin/logs.test.js
@@ -2,7 +2,7 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
 import { getAuthenticatedClient } from '../testutil';
 
-describe('App Logs V2', () => {
+describe('App Logs', () => {
   let test = new StitchMongoFixture();
   let app;
   let apps;
@@ -12,9 +12,9 @@ describe('App Logs V2', () => {
   beforeEach(async () => {
     let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
     test.groupId = test.userData.group.groupId;
-    apps = await adminClient.v2().apps(test.groupId);
+    apps = await adminClient.apps(test.groupId);
     app = await apps.create({ name: 'testname' });
-    logs = adminClient.v2().apps(test.groupId).app(app._id).logs();
+    logs = adminClient.apps(test.groupId).app(app._id).logs();
   });
   afterEach(async () => {
     await apps.app(app._id).remove();

--- a/test/admin/pipelines.test.js
+++ b/test/admin/pipelines.test.js
@@ -2,7 +2,11 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
 import {getAuthenticatedClient} from '../testutil';
 
-describe('Pipelines V2', ()=>{
+// the below tests are only supported in the deprecated v2 api
+// once the ability to query for both named pipelines and incoming webhooks with pipelines
+// is no longer needed, this can be removed.
+
+describe('Pipelines (V2)', ()=>{
   let test = new StitchMongoFixture();
   let apps;
   let app;

--- a/test/admin/push.test.js
+++ b/test/admin/push.test.js
@@ -2,7 +2,7 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
 import { getAuthenticatedClient } from '../testutil';
 
-describe('Push Notifications V2', () => {
+describe('Push Notifications', () => {
   let test = new StitchMongoFixture();
   let pushNotifications;
   let app;
@@ -12,10 +12,9 @@ describe('Push Notifications V2', () => {
   beforeEach(async () => {
     let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
     test.groupId = test.userData.group.groupId;
-    apps = await adminClient.v2().apps(test.groupId);
+    apps = await adminClient.apps(test.groupId);
     app = await apps.create({ name: 'testname' });
     pushNotifications = adminClient
-      .v2()
       .apps(test.groupId)
       .app(app._id)
       .pushNotifications();
@@ -30,7 +29,7 @@ describe('Push Notifications V2', () => {
     type: DRAFT_TYPE,
     message: 'this is a test notification.',
     label: 'test',
-    topic: 'v2'
+    topic: 'notifications'
   };
 
   it('listing draft push notifications should return empty list', async () => {

--- a/test/admin/service.test.js
+++ b/test/admin/service.test.js
@@ -2,7 +2,7 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
 import {getAuthenticatedClient} from '../testutil';
 
-describe('Services V2', ()=>{
+describe('Services', ()=>{
   let test = new StitchMongoFixture();
   let services;
   let app;
@@ -12,9 +12,9 @@ describe('Services V2', ()=>{
   beforeEach(async () =>{
     let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
     test.groupId = test.userData.group.groupId;
-    apps = await adminClient.v2().apps(test.groupId);
+    apps = await adminClient.apps(test.groupId);
     app = await apps.create({name: 'testname'});
-    services = adminClient.v2().apps(test.groupId).app(app._id).services();
+    services = adminClient.apps(test.groupId).app(app._id).services();
   });
   afterEach(async () => {
     await apps.app(app._id).remove();

--- a/test/admin/users.test.js
+++ b/test/admin/users.test.js
@@ -2,7 +2,7 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 import {getAuthenticatedClient} from '../testutil';
 
 
-describe('Users V2', ()=>{
+describe('Users', ()=>{
   let test = new StitchMongoFixture();
   let appUsers;
   beforeAll(() => test.setup());
@@ -10,11 +10,10 @@ describe('Users V2', ()=>{
   beforeEach(async () =>{
     let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
     test.groupId = test.userData.group.groupId;
-    let apiV2 = adminClient.v2();
-    let apps = await apiV2.apps(test.groupId);
+    let apps = await adminClient.apps(test.groupId);
     let app = await apps.create({name: 'testname'});
-    appUsers = adminClient.v2().apps(test.groupId).app(app._id).users();
-    let authProviders = adminClient.v2().apps(test.groupId).app(app._id).authProviders();
+    appUsers = adminClient.apps(test.groupId).app(app._id).users();
+    let authProviders = adminClient.apps(test.groupId).app(app._id).authProviders();
     let newProvider = await authProviders.create({type: 'local-userpass', config: {
       emailConfirmationUrl: 'http://emailConfirmURL.com',
       resetPasswordUrl: 'http://resetPasswordURL.com',

--- a/test/admin/values.test.js
+++ b/test/admin/values.test.js
@@ -2,7 +2,7 @@ const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
 import {getAuthenticatedClient} from '../testutil';
 
-describe('Values V2', ()=>{
+describe('Values', ()=>{
   let test = new StitchMongoFixture();
   let apps;
   let app;
@@ -11,9 +11,9 @@ describe('Values V2', ()=>{
   beforeEach(async () =>{
     let adminClient = await getAuthenticatedClient(test.userData.apiKey.key);
     test.groupId = test.userData.group.groupId;
-    apps = await adminClient.v2().apps(test.groupId);
+    apps = await adminClient.apps(test.groupId);
     app = await apps.create({name: 'testname'});
-    appValues = adminClient.v2().apps(test.groupId).app(app._id).values();
+    appValues = adminClient.apps(test.groupId).app(app._id).values();
   });
   afterEach(async () => {
     await apps.app(app._id).remove();

--- a/test/services/mongodb.test.js
+++ b/test/services/mongodb.test.js
@@ -9,8 +9,8 @@ let stripObjectIds = (data) => data.map(d => { delete d._id; return d; });
 
 async function testSetup(fixture) {
   await fixture.cleanTestNamespaces();
-  const newApp = await fixture.admin.v2().apps(fixture.userData.group.groupId).create({name: 'test'});
-  const app = fixture.admin.v2().apps(fixture.userData.group.groupId).app(newApp._id);
+  const newApp = await fixture.admin.apps(fixture.userData.group.groupId).create({name: 'test'});
+  const app = fixture.admin.apps(fixture.userData.group.groupId).app(newApp._id);
   const providers = await app.authProviders().list();
   await app.authProviders().authProvider(providers[0]._id).enable();
   const newKey = await app.apiKeys().create({name: 'test'});


### PR DESCRIPTION
Recap for [STITCH-880](https://jira.mongodb.org/browse/STITCH-880):
* Moved `v3` endpoints to top level admin client `app( groupId )` function
* Removed `v1` endpoints entirely
* Maintains `v2` endpoints (with `v3` functionality omitted ... functions & dev execute function)
  * The only test coverage for `v2` endpoints now are `pipelines.test.js` & one test in `dev.test.js` for executing pipelines.  **Should this change to have existing `v3` test files duplicated and ran against `v2` as well?**