### PR TITLE
Fix StitchError stack traces in node

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,11 +6,12 @@
         "node": "6"
       },
       "useBuiltins": "usage",
-    }]
+    }],
   ],
   "plugins": [
     "transform-async-to-generator",
     "babel-plugin-add-module-exports",
-    "version-transform"
+    "version-transform",
+    ["babel-plugin-transform-builtin-extend", { globals: ["Error"] }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-loader": "^7.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.6.1",
     "conventional-changelog-cli": "^1.3.1",
     "eslint": "^3.19.0",

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,9 @@
+import { StitchError } from '../src/errors';
+
+describe('StitchError', () => {
+  it('reports a full stack trace', () => {
+    const err = new StitchError("Oh noes!");
+    expect(err.toString()).toEqual('StitchError: Oh noes!');
+    expect(err.stack.length).toBeGreaterThan(err.toString().length);
+  });
+});


### PR DESCRIPTION
* Add `babel-plugin-transform-builtin-extend`
* Subclassing builtin types needs special treatment by babel
  * Without this plugin, in a node environment, a subclass of Error does not actually behave like a true subclass, which manifests itself via a missing stacktrace when a StitchError is thrown

#### More details [here](https://github.com/babel/babel/issues/3083)

We've been seeing a handful of flaky tests in evergreen caused by uncaught promises. Because of the missing stacktraces, these errors are super hard to track down. This should help with that.

### Before
![screen shot 2017-11-14 at 3 20 48 pm](https://user-images.githubusercontent.com/2425496/32802819-6d59bb26-c94f-11e7-80c6-82ec70d01a1b.png)

### After
![screen shot 2017-11-14 at 3 20 11 pm](https://user-images.githubusercontent.com/2425496/32802822-72c74f24-c94f-11e7-8053-a9ee90bf76f5.png)

