### PR TITLE
use .execute() to force execution of find queries

### DIFF
--- a/src/services/mongodb/collection.js
+++ b/src/services/mongodb/collection.js
@@ -187,12 +187,8 @@ MongoQuery.prototype.sort = function(sort) {
   return this;
 };
 
-MongoQuery.prototype.then = function(resolve) {
-  return findOp(this).then(resolve);
-};
-
-MongoQuery.prototype.catch = function(reject) {
-  return findOp(this).catch(reject);
+MongoQuery.prototype.execute = function(resolve) {
+  return findOp(this);
 };
 
 export default Collection;

--- a/test/client/mongodb_service.test.js
+++ b/test/client/mongodb_service.test.js
@@ -150,7 +150,7 @@ describe('Client API executing mongodb service functions', () => {
 
     await service.insertMany(testDocs);
 
-    const foundDocs = await service.find({ b: 'be' }).limit(1000);
+    const foundDocs = await service.find({ b: 'be' }).limit(1000).execute();
 
     expect(foundDocs).toHaveLength(1);
     expect(foundDocs[0]).toMatchObject(testDocs[3]);
@@ -166,7 +166,7 @@ describe('Client API executing mongodb service functions', () => {
 
     await service.insertMany(testDocs);
 
-    const foundDocs = await service.find({ d: 0 }, { c: 1 }).limit(10000);
+    const foundDocs = await service.find({ d: 0 }, { c: 1 }).limit(10000).execute();
 
     expect(foundDocs).toHaveLength(4);
     expect(foundDocs).toMatchObject([{ c: 'braves' }, { c: 'patriots' }, { c: 'chipper' }, { c: 'tom' }]);
@@ -182,8 +182,7 @@ describe('Client API executing mongodb service functions', () => {
 
     await service.insertMany(testDocs);
 
-    const foundDocs = await service.find({ b: 'bee' })
-      .limit(2);
+    const foundDocs = await service.find({ b: 'bee' }).limit(2).execute();
 
     expect(foundDocs).toHaveLength(2);
     expect(foundDocs).toMatchObject(testDocs.splice(0, 2));
@@ -200,7 +199,7 @@ describe('Client API executing mongodb service functions', () => {
     await service.insertMany(testDocs);
 
     const foundDocs = await service.find({ d: 0 })
-      .sort({ a: -1 }).limit(1000);
+      .sort({ a: -1 }).limit(1000).execute();
 
     expect(foundDocs).toHaveLength(4);
     expect(foundDocs).toMatchObject(testDocs.reverse());
@@ -218,7 +217,8 @@ describe('Client API executing mongodb service functions', () => {
 
     const foundDocs = await service.find({ b: 'bee' }, { a: 1 })
       .limit(1)
-      .sort({ a: -1 });
+      .sort({ a: -1 })
+      .execute();
 
     expect(foundDocs).toHaveLength(1);
     expect(foundDocs[0]).toMatchObject({ a: 3 });


### PR DESCRIPTION
cc @makesitgo so we have to back out the `.then`/`.catch` trick because it doesn't play so nicely with some promise APIs. An explicit `.execute()` method seems to be the best way to do this without it being too confusing.
will need to update the getting started example to include this change, i'll get to that next.