### PR TITLE
STITCH-931 - HTTP Service Integration Tests

### DIFF
--- a/src/services/http/http_service.js
+++ b/src/services/http/http_service.js
@@ -25,12 +25,10 @@ class HTTPService {
   }
 
   /**
-   * Send a POST request to a resource with payload from previous stage
-   *
-   * NOTE: item from previous stage must serializable to application/json
+   * Send a POST request to a resource with payload
    *
    * @param {String|Object} urlOrOptions the url to request, or an object of POST args
-   * @param {Object} [options] optional settings for the GET operation
+   * @param {Object} [options] optional settings for the POST operation
    * @param {String} [options.authUrl] url that grants a cookie
    * @return {Promise}
    */
@@ -39,12 +37,10 @@ class HTTPService {
   }
 
   /**
-   * Send a PUT request to a resource with payload from previous stage
+   * Send a PUT request to a resource with payload
    *
-   * NOTE: item from previous stage must serializable to application/json
-   *
-   * @param {String|Object} urlOrOptions the url to request, or an object of POST args
-   * @param {Object} [options] optional settings for the GET operation
+   * @param {String|Object} urlOrOptions the url to request, or an object of PUT args
+   * @param {Object} [options] optional settings for the PUT operation
    * @param {String} [options.authUrl] url that grants a cookie
    * @return {Promise}
    */
@@ -53,12 +49,10 @@ class HTTPService {
   }
 
   /**
-   * Send a PATCH request to a resource with payload from previous stage
+   * Send a PATCH request to a resource with payload
    *
-   * NOTE: item from previous stage must serializable to application/json
-   *
-   * @param {String|Object} urlOrOptions the url to request, or an object of POST args
-   * @param {Object} [options] optional settings for the GET operation
+   * @param {String|Object} urlOrOptions the url to request, or an object of PATCH args
+   * @param {Object} [options] optional settings for the PATCH operation
    * @param {String} [options.authUrl] url that grants a cookie
    * @return {Promise}
    */
@@ -69,8 +63,8 @@ class HTTPService {
   /**
    * Send a DELETE request to a resource
    *
-   * @param {String|Object} urlOrOptions the url to request, or an object of POST args
-   * @param {Object} [options] optional settings for the GET operation
+   * @param {String|Object} urlOrOptions the url to request, or an object of DELETE args
+   * @param {Object} [options] optional settings for the DELETE operation
    * @param {String} [options.authUrl] url that grants a cookie
    * @return {Promise}
    */
@@ -81,8 +75,8 @@ class HTTPService {
   /**
    * Send a HEAD request to a resource
    *
-   * @param {String|Object} urlOrOptions the url to request, or an object of POST args
-   * @param {Object} [options] optional settings for the GET operation
+   * @param {String|Object} urlOrOptions the url to request, or an object of HEAD args
+   * @param {Object} [options] optional settings for the HEAD operation
    * @param {String} [options.authUrl] url that grants a cookie
    * @return {Promise}
    */

--- a/test/client/http_service.test.js
+++ b/test/client/http_service.test.js
@@ -1,0 +1,314 @@
+const SimpleHttpServer = require('../fixtures/simple_http_server');
+const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
+
+import { buildClientTestHarness, extractTestFixtureDataPoints } from '../testutil';
+
+describe('Executing http service functions', () => {
+  const server = new SimpleHttpServer();
+  const test = new StitchMongoFixture();
+
+  beforeAll(() => test.setup());
+  afterAll(() => test.teardown());
+
+  const SERVICE_TYPE = 'http';
+  const SERVICE_NAME = 'gd2';
+
+  let th;
+  let service;
+  let serviceId;
+
+  beforeEach(async() => {
+    const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
+    th = await buildClientTestHarness(apiKey, groupId, serverUrl);
+
+    const httpService = await th
+      .app()
+      .services()
+      .create({ type: SERVICE_TYPE, name: SERVICE_NAME });
+
+    service = th.stitchClient.service(SERVICE_TYPE, SERVICE_NAME);
+    serviceId = httpService._id;
+  });
+
+  afterEach(() => th.cleanup());
+
+  describe('That have no matching service rules', () => {
+    it('should fail due to no matching rule found', async() => {
+      expect(service.get(server.url)).rejects.toMatchObject({
+        name: 'StitchError',
+        code: 'NoMatchingRuleFound',
+        response: { status: 403 }
+      });
+    });
+  });
+
+  describe('That have proper service rules created', () => {
+    beforeEach(async() => {
+      await th
+        .app()
+        .services()
+        .service(serviceId)
+        .rules()
+        .create({
+          name: 'testRule',
+          actions: ['get', 'post', 'put', 'patch', 'delete', 'head'],
+          when: {}
+        });
+    });
+
+    describe('And an unavailable mock server', () => {
+      it('should fail due to a function execution error', async() => {
+        expect(service.get(server.url)).rejects.toMatchObject({
+          name: 'StitchError',
+          code: 'FunctionExecutionError',
+          response: { status: 400 }
+        });
+      });
+    });
+
+    describe('And an available mock server', () => {
+      beforeAll(() => server.listen());
+      afterAll(() => server.close());
+
+      describe('Submitting an invalid request', () => {
+        it('should fail when an invalid url value is supplied', async() => {
+          expect(service.get({ url: 'invalidurl' })).rejects.toMatchObject({
+            name: 'StitchError',
+            code: 'FunctionExecutionError',
+            response: { status: 400 }
+          });
+        });
+
+        it('should fail when an invalid url datatype is supplied', async() => {
+          expect(service.get({ url: 10281995 })).rejects.toMatchObject({
+            name: 'StitchError',
+            code: 'InvalidParameter',
+            response: { status: 400 }
+          });
+        });
+
+        it('should fail when both url and scheme+host are supplied', async() => {
+          expect(
+            service.get({
+              url: 'http://locahost',
+              scheme: 'http',
+              host: 'localhost'
+            })
+          ).rejects.toMatchObject({
+            name: 'StitchError',
+            code: 'InvalidParameter',
+            response: { status: 400 }
+          });
+        });
+      });
+
+      describe('Submitting a GET request', () => {
+        beforeAll(() => server.mockRequestHandler()
+          .setStatusCode(200)
+          .addHeader('Content-Type', 'text/plain')
+          .addHeader('Warning', '622 Test GET warning')
+          .textResponse('POW!'));
+
+        it('with a string argument should send a successful request', async() => {
+          const { statusCode, headers, body } = await service.get(server.url);
+
+          expect(statusCode).toBe(200);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test GET warning');
+          expect(body.toString()).toBe('POW!');
+        });
+
+        it('with an object argument should send a successful request', async() => {
+          const { statusCode, headers, body } = await service.get({ url: server.url });
+
+          expect(statusCode).toBe(200);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test GET warning');
+          expect(body.toString()).toBe('POW!');
+        });
+      });
+
+      describe('Submitting a POST request', () => {
+        beforeAll(() => server.mockRequestHandler()
+          .setStatusCode(201)
+          .addHeader('Content-Type', 'text/plain')
+          .addHeader('Warning', '622 Test POST warning')
+          .echoResponse());
+
+        it('with a string argument should send a successful request and return an empty response body', async() => {
+          const { statusCode, headers, body } = await service.post(server.url);
+
+          expect(statusCode).toBe(201);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test POST warning');
+          expect(body.toString()).toBe('');
+        });
+
+        it('with an object argument containing the raw request body should send a successful request', async() => {
+          const requestBody = { foo: 'bar' };
+          const { statusCode, headers, body } = await service.post({
+            url: server.url,
+            body: requestBody,
+            encodeBodyAsJSON: true
+          });
+
+          expect(statusCode).toBe(201);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test POST warning');
+          expect(body.toString()).toBe(JSON.stringify(requestBody));
+        });
+
+        it('with an object argument containing the stringified request body should send a successful request', async() => {
+          const requestBody = JSON.stringify({ foo: 'bar' });
+          const { statusCode, headers, body } = await service.post({
+            url: server.url,
+            body: requestBody
+          });
+
+          expect(statusCode).toBe(201);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test POST warning');
+          expect(body.toString()).toBe(requestBody);
+        });
+      });
+
+      describe('Submitting a PUT request', () => {
+        beforeAll(() => server.mockRequestHandler()
+          .setStatusCode(201)
+          .addHeader('Content-Type', 'text/plain')
+          .addHeader('Warning', '622 Test PUT warning')
+          .echoResponse());
+
+        it('with a string argument should send a successful request and return an empty response body', async() => {
+          const { statusCode, headers, body } = await service.put(server.url);
+
+          expect(statusCode).toBe(201);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test PUT warning');
+          expect(body.toString()).toBe('');
+        });
+
+        it('with an object argument containing the raw request body should send a successful request', async() => {
+          const requestBody = { foo: 'bar' };
+          const { statusCode, headers, body } = await service.put({
+            url: server.url,
+            body: requestBody,
+            encodeBodyAsJSON: true
+          });
+
+          expect(statusCode).toBe(201);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test PUT warning');
+          expect(body.toString()).toBe(JSON.stringify(requestBody));
+        });
+
+        it('with an object argument containing the stringified request body should send a successful request', async() => {
+          const requestBody = JSON.stringify({ foo: 'bar' });
+          const { statusCode, headers, body } = await service.put({
+            url: server.url,
+            body: requestBody
+          });
+
+          expect(statusCode).toBe(201);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test PUT warning');
+          expect(body.toString()).toBe(requestBody);
+        });
+      });
+
+      describe('Submitting a PATCH request', () => {
+        beforeAll(() => server.mockRequestHandler()
+          .setStatusCode(206)
+          .addHeader('Content-Type', 'text/plain')
+          .addHeader('Warning', '622 Test PATCH warning')
+          .echoResponse());
+
+        it('with a string argument should send a successful request and return an empty response body', async() => {
+          const { statusCode, headers, body } = await service.patch(server.url);
+
+          expect(statusCode).toBe(206);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test PATCH warning');
+          expect(body.toString()).toBe('');
+        });
+
+        it('with an object argument containing the raw request body should send a successful request', async() => {
+          const requestBody = { foo: 'bar' };
+          const { statusCode, headers, body } = await service.patch({
+            url: server.url,
+            body: requestBody,
+            encodeBodyAsJSON: true
+          });
+
+          expect(statusCode).toBe(206);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test PATCH warning');
+          expect(body.toString()).toBe(JSON.stringify(requestBody));
+        });
+
+        it('with an object argument containing the stringified request body should send a successful request', async() => {
+          const requestBody = JSON.stringify({ foo: 'bar' });
+          const { statusCode, headers, body } = await service.patch({
+            url: server.url,
+            body: requestBody
+          });
+
+          expect(statusCode).toBe(206);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test PATCH warning');
+          expect(body.toString()).toBe(requestBody);
+        });
+      });
+
+      describe('Submitting a DELETE request', () => {
+        beforeAll(() => server.mockRequestHandler()
+          .setStatusCode(202)
+          .addHeader('Content-Type', 'text/plain')
+          .addHeader('Warning', '622 Test DELETE warning'));
+
+        it('with a string argument should send a successful request', async() => {
+          const { statusCode, headers, body } = await service.delete(server.url);
+
+          expect(statusCode).toBe(202);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test DELETE warning');
+          expect(body.toString()).toBe('');
+        });
+
+        it('with an object argument should send a successful request', async() => {
+          const { statusCode, headers, body } = await service.delete({ url: server.url });
+
+          expect(statusCode).toBe(202);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test DELETE warning');
+          expect(body.toString()).toBe('');
+        });
+      });
+
+      describe('Submitting a HEAD request', () => {
+        beforeAll(() => server.mockRequestHandler()
+          .setStatusCode(200)
+          .addHeader('Content-Type', 'text/plain')
+          .addHeader('Warning', '622 Test HEAD warning'));
+
+        it('with a string argument should send a successful request', async() => {
+          const { statusCode, headers, body } = await service.head(server.url);
+
+          expect(statusCode).toBe(200);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test HEAD warning');
+          expect(body.toString()).toBe('');
+        });
+
+        it('with an object argument should send a successful request', async() => {
+          const { statusCode, headers, body } = await service.head({ url: server.url });
+
+          expect(statusCode).toBe(200);
+          expect(headers['Content-Type']).toContain('text/plain');
+          expect(headers['Warning']).toContain('622 Test HEAD warning');
+          expect(body.toString()).toBe('');
+        });
+      });
+    });
+  });
+});

--- a/test/fixtures/simple_http_server.js
+++ b/test/fixtures/simple_http_server.js
@@ -1,0 +1,77 @@
+const http = require('http');
+
+export default class SimpleServer {
+  constructor(port = 7000) {
+    this.port = port;
+    this.mockRequestHandler();
+
+    this.server = http.createServer(async(req, res) => {
+      res.writeHead(this.requestHandler.statusCode, this.requestHandler.headers);
+      res.end(await this.requestHandler.dataCreator(req));
+    });
+  }
+
+  close() {
+    this.server.close();
+  }
+
+  listen() {
+    this.server.listen(this.port);
+  }
+
+  get url() {
+    return `http://localhost:${this.port}`;
+  }
+
+  mockRequestHandler(statusCode, headers, dataCreator) {
+    this.requestHandler = new MockRequestHandler({ statusCode, headers, dataCreator });
+    return this.requestHandler;
+  }
+}
+
+function MockRequestHandler({ statusCode = 500, headers = {}, dataCreator = req => {} }) {
+  if (this instanceof MockRequestHandler) {
+    this.statusCode = statusCode;
+    this.headers = headers;
+    this.dataCreator = dataCreator;
+    return this;
+  }
+  return new MockRequestHandler({ statusCode, headers, dataCreator });
+}
+
+MockRequestHandler.prototype.setStatusCode = function(statusCode) {
+  this.statusCode = statusCode;
+  return this;
+};
+
+MockRequestHandler.prototype.addHeader = function(name, value) {
+  this.headers[name] = value;
+  return this;
+};
+
+MockRequestHandler.prototype.setHeaders = function(headers) {
+  this.headers = headers;
+  return this;
+};
+
+MockRequestHandler.prototype.echoResponse = function() {
+  return this.setDataCreator(
+    req =>
+      new Promise((resolve, reject) => {
+        const body = [];
+        req
+          .on('data', chunk => body.push(chunk))
+          .on('end', () => resolve(Buffer.concat(body).toString()))
+          .on('error', err => reject(err));
+      })
+  );
+};
+
+MockRequestHandler.prototype.textResponse = function(text) {
+  return this.setDataCreator(req => text);
+};
+
+MockRequestHandler.prototype.setDataCreator = function(dataCreator) {
+  this.dataCreator = dataCreator;
+  return this;
+};


### PR DESCRIPTION
**Test Output:**
```cmd
 PASS  test/client/http_service.test.js
  Executing http service functions
    That have no matching service rules
      ✓ should fail due to no matching rule found (137ms)
    That have proper service rules created
      And an unavailable mock server
        ✓ should fail due to a function execution error (120ms)
      And an available mock server
        Submitting an invalid request
          ✓ should fail when an invalid url value is supplied (96ms)
          ✓ should fail when an invalid url datatype is supplied (80ms)
          ✓ should fail when both url and scheme+host are supplied (82ms)
        Submitting a GET request
          ✓ with a string argument should send a successful request (114ms)
          ✓ with an object argument should send a successful request (87ms)
        Submitting a POST request
          ✓ with a string argument should send a successful request and return an empty response body (99ms)
          ✓ with an object argument containing the raw request body should send a successful request (110ms)
          ✓ with an object argument containing the stringified request body should send a successful request (87ms)
        Submitting a PUT request
          ✓ with a string argument should send a successful request and return an empty response body (98ms)
          ✓ with an object argument containing the raw request body should send a successful request (83ms)
          ✓ with an object argument containing the stringified request body should send a successful request (85ms)
        Submitting a PATCH request
          ✓ with a string argument should send a successful request and return an empty response body (94ms)
          ✓ with an object argument containing the raw request body should send a successful request (86ms)
          ✓ with an object argument containing the stringified request body should send a successful request (101ms)
        Submitting a DELETE request
          ✓ with a string argument should send a successful request (79ms)
          ✓ with an object argument should send a successful request (83ms)
        Submitting a HEAD request
          ✓ with a string argument should send a successful request (91ms)
          ✓ with an object argument should send a successful request (80ms)
```