### PR TITLE
fix documented return type for authedId() in StitchClient

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -184,7 +184,7 @@ export default class StitchClient {
       .then(response => response.json());
   }
   /**
-   *  @return {String} Returns the currently authed user's ID.
+   *  @return {Promise} Returns a promise resolving to a string of the currently authed user's ID.
    */
   authedId() {
     return this.auth.authedId();


### PR DESCRIPTION
With the React Native improvements, the return type for authedId() is now a promise, which should be properly documented