### PR TITLE
STITCH-1180 Improve instance member links in generated documentation

### DIFF
--- a/docs_theme/assets/site.js
+++ b/docs_theme/assets/site.js
@@ -64,6 +64,19 @@ function toggleSibling() {
   }
 }
 
+function forceOpenSibling(targetId) {
+  var hashTarget = document.getElementById(targetId);
+  var stepSibling = hashTarget.getElementsByClassName('toggle-target')[0];
+  if(stepSibling) {
+    var icon = hashTarget.getElementsByClassName('icon')[0];
+    var klass = 'display-none';
+    if (stepSibling.classList.contains(klass)) {
+      stepSibling.classList.remove(klass);
+      icon.innerHTML = '▾';
+    }
+  }
+}
+
 function showHashTarget(targetId) {
   if (targetId) {
     var hashTarget = document.getElementById(targetId);
@@ -91,6 +104,7 @@ function scrollIntoView(targetId) {
 function gotoCurrentTarget() {
   showHashTarget(location.hash.substring(1));
   scrollIntoView(location.hash.substring(1));
+  forceOpenSibling(location.hash.substring(1));
 }
 
 window.addEventListener('hashchange', gotoCurrentTarget);

--- a/docs_theme/assets/site.js
+++ b/docs_theme/assets/site.js
@@ -66,13 +66,15 @@ function toggleSibling() {
 
 function forceOpenSibling(targetId) {
   var hashTarget = document.getElementById(targetId);
-  var stepSibling = hashTarget.getElementsByClassName('toggle-target')[0];
-  if(stepSibling) {
-    var icon = hashTarget.getElementsByClassName('icon')[0];
-    var klass = 'display-none';
-    if (stepSibling.classList.contains(klass)) {
-      stepSibling.classList.remove(klass);
-      icon.innerHTML = '▾';
+  if(hashTarget) {
+    var stepSibling = hashTarget.getElementsByClassName('toggle-target')[0];
+      if(stepSibling) {
+      var icon = hashTarget.getElementsByClassName('icon')[0];
+      var klass = 'display-none';
+      if (stepSibling.classList.contains(klass)) {
+        stepSibling.classList.remove(klass);
+        icon.innerHTML = '▾';
+      }
     }
   }
 }

--- a/docs_theme/assets/style.css
+++ b/docs_theme/assets/style.css
@@ -29,6 +29,14 @@
   font-family: Source Code Pro,Menlo,Consolas,Liberation Mono,monospace;
 }
 
+.toggle-sibling {
+  cursor: pointer;
+}
+
+.toggle-sibling:hover {
+  background-color: #f5f5f5;
+}
+
 h4 {
   margin: 20px 0 10px 0;
 }

--- a/docs_theme/assets/style.css
+++ b/docs_theme/assets/style.css
@@ -29,11 +29,11 @@
   font-family: Source Code Pro,Menlo,Consolas,Liberation Mono,monospace;
 }
 
-.toggle-sibling {
+#split-right .toggle-sibling {
   cursor: pointer;
 }
 
-.toggle-sibling:hover {
+#split-right .toggle-sibling:hover {
   background-color: #f5f5f5;
 }
 


### PR DESCRIPTION
Two small changes to the UI for the docs:

* Hash links to specific instance/static members (e.g. https://s3.amazonaws.com/stitch-sdks/js/docs/master/index.html#collectioninsertmany) of a class will automatically open the description of that member.
* In the list of instance/static members for each class, the clickable area to open the description now has a pointer cursor and a slight gray color when hovering.