### PR TITLE
[STITCH-2183] Make support/3.x branch green again

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -18,7 +18,7 @@ functions:
           cd mongodb-*
           echo "starting mongod..."
           mkdir db_files
-          ./bin/mongod --dbpath ./db_files --port 26000 &
+          ./bin/mongod --dbpath ./db_files --port 26000 --replSet test &
           echo "waiting for mongod to start up"
     - command: shell.exec
       params:
@@ -26,6 +26,7 @@ functions:
           set -e
           cd mongodb-*
           ./bin/mongo --nodb --eval 'assert.soon(function(x){try{var d = new Mongo("localhost:26000"); return true}catch(e){return false}}, "timed out connecting")'
+          ./bin/mongo --port 26000 --eval 'rs.initiate()'
           echo "mongod is up."
 
   "setup_stitch":
@@ -88,7 +89,7 @@ tasks:
       - func: "setup_mongod"
       - func: "setup_stitch"
       - command: shell.exec
-        params: 
+        params:
           script: | # NOTE: Using yarn for install instead of npm due to evergreen permission issue with chromedriver devDependency
             set -e
             echo "running client tests"
@@ -212,12 +213,12 @@ tasks:
             export PATH=$HOME/bin:$PATH
             export AWS_ACCESS_KEY_ID=${sdks_aws_key}
             export AWS_SECRET_ACCESS_KEY=${sdks_aws_secret}
-            
+
             if [ "${is_patch|}" = "true" ]; then
                 # Avoids clobbering docs from other patches or non-patch tasks under the same base commit.
                 aws s3 cp stitch-js-sdk/docs s3://stitch-sdks/js/docs/${version_id} --recursive --acl public-read
             else
-                cd stitch-js-sdk 
+                cd stitch-js-sdk
                 export TAG_OR_REV="$(git describe --exact-match || echo ${revision})"
                 cd ..
                 aws s3 cp stitch-js-sdk/docs s3://stitch-sdks/js/docs/$TAG_OR_REV --recursive --acl public-read
@@ -242,7 +243,7 @@ buildvariants:
   run_on:
     - baas-linux
   expansions:
-    mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.4.4.tgz
+    mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel70-4.0.2.tgz
     transpiler_target: node8-linux
   tasks:
     - name: run_tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-stitch",
-  "version": "3.2.9",
+  "version": "3.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -59,12 +59,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-      "dev": true
-    },
-    "@types/jest": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.1.0.tgz",
-      "integrity": "sha512-DlIvvYDpcFgM1Ny1uzUBGb+0UMejhPEzDGxJ2By75ndMVDa82OUzPlV+v6NOsjA7HRvB4oj/Jqsscv6eJvLxeQ==",
       "dev": true
     },
     "Base64": {
@@ -2144,16 +2138,135 @@
       }
     },
     "chromedriver": {
-      "version": "2.33.2",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.33.2.tgz",
-      "integrity": "sha512-etnQeM8Mqiys50ZB4IiuNqeB1WS2/EKFhVXwkPQ1qjzKMMAJUyrLjaRUcoZoHrbjGscnhBrWkRR+p3zcTGMhDg==",
+      "version": "2.44.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.44.1.tgz",
+      "integrity": "sha512-IPM8XQzQYVNJ9Rfec5cy0aGbrZno5xUlDNLLuph9bjkTJVoi14zqjvtmRd8Dc1P5vTw0MwNQ5JD89zibXp/W5A==",
       "dev": true,
       "requires": {
         "del": "^3.0.0",
-        "extract-zip": "^1.6.5",
-        "kew": "^0.7.0",
+        "extract-zip": "^1.6.7",
         "mkdirp": "^0.5.1",
-        "request": "^2.83.0"
+        "request": "^2.88.0",
+        "tcp-port-used": "^1.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
+          "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+          "dev": true
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.37.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+          "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.21",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+          "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.37.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
+        }
       }
     },
     "ci-info": {
@@ -2483,6 +2596,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+          "dev": true
+        }
       }
     },
     "cross-spawn": {
@@ -5722,6 +5853,12 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
     "ipaddr.js": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
@@ -6088,6 +6225,12 @@
         "unc-path-regex": "^0.1.2"
       }
     },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -6118,6 +6261,17 @@
       "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
       "dev": true
     },
+    "is2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
+      "integrity": "sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "ip-regex": "^2.1.0",
+        "is-url": "^1.2.2"
+      }
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -6137,16 +6291,6 @@
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
-      }
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -6594,13 +6738,12 @@
       }
     },
     "jest-fetch-mock": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-1.6.5.tgz",
-      "integrity": "sha512-qPz5Zf8+W16pu6cvdwXkb2SwRfxGoQbbGB6HcIBFND0gnWKMfQilZew3PSODnOWQZF/pzBPi7ZIT6Yz5D0va1Q==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-1.7.5.tgz",
+      "integrity": "sha512-fP0CXb24z5oyvHiqakvDiDqEik1LPmIgRqsrqLhXkMNqSfibfsDkP5VJzm9/rmVsT9WSGQGNZ4iD2f1/Sm0qmg==",
       "dev": true,
       "requires": {
-        "@types/jest": "^23.0.0",
-        "isomorphic-fetch": "^2.2.1",
+        "cross-fetch": "^2.2.2",
         "promise-polyfill": "^7.1.1"
       }
     },
@@ -7420,12 +7563,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.0.tgz",
       "integrity": "sha1-P55JkK3K0MaGwOcB92RYaPdfkes=",
-      "dev": true
-    },
-    "kew": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
     "keyv": {
@@ -9170,6 +9307,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
       "dev": true
     },
     "public-encrypt": {
@@ -11019,6 +11162,33 @@
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
     },
+    "tcp-port-used": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
+      "integrity": "sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==",
+      "dev": true,
+      "requires": {
+        "debug": "4.1.0",
+        "is2": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
     "test-exclude": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
@@ -11859,6 +12029,23 @@
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
       "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "fetch-mock": "^5.10.1",
     "gh-pages": "^1.0.0",
     "jest": "^22.2.2",
-    "jest-fetch-mock": "^1.1.1",
+    "jest-fetch-mock": "^1.7.5",
     "md5": "^2.2.1",
     "mock-browser": "^0.92.14",
     "mongodb": "^2.2.26",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-version-transform": "^1.0.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.1",
-    "chromedriver": "2.33.2",
+    "chromedriver": "^2.36.0",
     "documentation": "^5.3.5",
     "eslint": "^4.7.2",
     "eslint-loader": "^1.7.1",

--- a/test/admin/admin_users.test.js
+++ b/test/admin/admin_users.test.js
@@ -23,7 +23,7 @@ describe('Admin Users', () => {
 
     const { roles } = await adminClient.userProfile();
     expect(roles).toBeDefined();
-    expect(roles.length).toBe(1);
+    expect(roles.length).toBe(2);
     expect(roles[0].role_name).toBe('groupOwner');
   });
 

--- a/test/admin/debug.test.js
+++ b/test/admin/debug.test.js
@@ -50,7 +50,7 @@ describe('Debugging functions', () => {
     const result = await debug.executeFunctionSource({
       userId: th.user._id,
       source: 'exports = function(arg1, arg2) { return {sum: 800 + arg1 + arg2, userId: context.user.id } }',
-      evalSource: 'exports(1,5)',
+      evalSource: 'exports(1,5)'
     });
 
     expect(result.result.sum).toEqual({'$numberDouble': '806'});
@@ -62,7 +62,7 @@ describe('Debugging functions', () => {
     const result = await debug.executeFunctionSource({
       runAsSystem: 'true',
       source: 'exports = function(arg1, arg2) { return {sum: 800 + arg1 + arg2, userId: context.user.id } }',
-      evalSource: 'exports(1,5)',
+      evalSource: 'exports(1,5)'
     });
 
     expect(result.result.sum).toEqual({'$numberDouble': '806'});

--- a/test/admin/event_subscriptions.test.js
+++ b/test/admin/event_subscriptions.test.js
@@ -28,8 +28,8 @@ function buildEventSubscriptionData(functionId) {
     disabled: true,
     function_id: functionId,
     config: {
-      action_type: 'LOGIN',
-      provider: 'api-key'
+      operation_type: 'LOGIN',
+      providers: ['api-key']
     }
   };
 }
@@ -115,7 +115,8 @@ describe('Event Subscriptions', () =>{
       {
         disabled: false,
         config: {
-          action_type: 'CREATE'
+          operation_type: 'CREATE',
+          providers: ['api-key']
         }
       }
     );
@@ -129,8 +130,8 @@ describe('Event Subscriptions', () =>{
         {
           disabled: false,
           config: {
-            action_type: 'CREATE',
-            provider: ''
+            operation_type: 'CREATE',
+            providers: ['api-key']
           }
         }
       )
@@ -144,7 +145,7 @@ describe('Event Subscriptions', () =>{
     const eventSubscriptionData = buildDBEventSubscriptionData(fn._id, mongodbService._id);
     const eventSubscription = await eventSubscriptions.create(eventSubscriptionData);
 
-    const resumedSubscription = await eventSubscriptions.eventSubscription(eventSubscription._id).resume();
+    const resumedSubscription = await eventSubscriptions.eventSubscription(eventSubscription._id).resume({ disable_token: false });
     expect(resumedSubscription.status).toEqual(204);
   });
 

--- a/test/admin/hosting.test.js
+++ b/test/admin/hosting.test.js
@@ -64,7 +64,6 @@ describe('Hosting', () => {
   it('getting an asset should work', async() => {
     const filePath = `/${randomString()}`;
     let { metadata, body } = createTestFile(filePath);
-    console.log(metadata);
     await hosting.assets().upload(JSON.stringify(metadata), body);
 
     let asset = await hosting.assets().asset().get({ path: filePath });

--- a/test/admin/logs.test.js
+++ b/test/admin/logs.test.js
@@ -20,6 +20,6 @@ describe('App Logs', () => {
 
   it('responds with an empty list of logs', async() => {
     let logsResponse = await logs.list();
-    expect(logsResponse).toEqual([]);
+    expect(logsResponse.logs).toEqual([]);
   });
 });

--- a/test/admin/service.test.js
+++ b/test/admin/service.test.js
@@ -193,7 +193,7 @@ describe('Services', ()=>{
     respond_result: true,
     options: {
       secret: '12345',
-      secretAsQueryParam: true
+      validationMethod: 'SECRET_AS_QUERY_PARAM'
     }
   };
 

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -42,11 +42,21 @@ function _runReverseMigration(toVersion, storage) {
   }
 }
 
+// The type of the item in storage differs between the MockBrowser and Evergreen
+function storageValue(value, storageType, isMocked) {
+  if (!isMocked && (storageType === 'localStorage' || storageType === 'sessionStorage')) {
+    return `${value}`;
+  }
+  return value;
+}
+
 describe('storage', function() {
   const namespace = 'client-test-app1';
+  let isMocked = false;
 
   beforeAll(() => {
     if (!global.window.localStorage || !global.window.sessionStorage) {
+      isMocked = true;
       let mock = new MockBrowser();
       global.window.localStorage = mock.getLocalStorage();
       global.window.sessionStorage = mock.getSessionStorage();
@@ -71,8 +81,8 @@ describe('storage', function() {
       await storage.set('foo', 42);
       await storage.set('bar', 84);
 
-      expect(storage.store.getItem(storage.store.key(2))).toEqual(84);
-      expect(storage.store.getItem(storage.store.key(1))).toEqual(42);
+      expect(storage.store.getItem(storage.store.key(2))).toEqual(storageValue(84, storageType, isMocked));
+      expect(storage.store.getItem(storage.store.key(1))).toEqual(storageValue(42, storageType, isMocked));
     });
 
     it(`should allow for two unique clients to coexist for ${storageType}`, async() => {
@@ -112,16 +122,16 @@ describe('storage', function() {
       await storage.set(USER_AUTH_KEY, 42);
       await storage.set(REFRESH_TOKEN_KEY, 84);
 
-      expect(await storage.get(USER_AUTH_KEY)).toEqual(42);
-      expect(await storage.get(REFRESH_TOKEN_KEY)).toEqual(84);
+      expect(await storage.get(USER_AUTH_KEY)).toEqual(storageValue(42, storageType, isMocked));
+      expect(await storage.get(REFRESH_TOKEN_KEY)).toEqual(storageValue(84, storageType, isMocked));
 
-      expect(storage.store.getItem(`_stitch.${namespace}.${USER_AUTH_KEY}`)).toEqual(42);
-      expect(storage.store.getItem(`_stitch.${namespace}.${REFRESH_TOKEN_KEY}`)).toEqual(84);
+      expect(storage.store.getItem(`_stitch.${namespace}.${USER_AUTH_KEY}`)).toEqual(storageValue(42, storageType, isMocked));
+      expect(storage.store.getItem(`_stitch.${namespace}.${REFRESH_TOKEN_KEY}`)).toEqual(storageValue(84, storageType, isMocked));
 
       await _runReverseMigration(undefined, storage);
 
-      expect(storage.store.getItem(USER_AUTH_KEY)).toEqual(42);
-      expect(storage.store.getItem(REFRESH_TOKEN_KEY)).toEqual(84);
+      expect(storage.store.getItem(USER_AUTH_KEY)).toEqual(storageValue(42, storageType, isMocked));
+      expect(storage.store.getItem(REFRESH_TOKEN_KEY)).toEqual(storageValue(84, storageType, isMocked));
     });
   }
 
@@ -175,5 +185,3 @@ describe('storage', function() {
     expect(storage.store.getItem(STATE_KEY)).toBeNull();
   });
 });
-
-

--- a/test/test.js
+++ b/test/test.js
@@ -156,7 +156,7 @@ describe('Auth', () => {
         envConfig.setup();
         fetchMock.post('/auth/providers/local-userpass/login', checkLogin);
         fetchMock.post(DEFAULT_STITCH_SERVER_URL + '/api/client/v2.0/app/testapp/auth/providers/local-userpass/login', checkLogin);
-        fetchMock.delete(SESSION_URL, {});
+        fetchMock.delete(SESSION_URL, 204);
         capturedDevice = undefined;
       });
 
@@ -322,6 +322,7 @@ describe('http error responses', () => {
   describe('JSON error responses are handled correctly', () => {
     beforeEach(() => {
       fetchMock.restore();
+      fetchMock.delete(SESSION_URL, 204);
       fetchMock.post(FUNCTION_CALL_URL, () =>
         ({
           body: {error: testErrMsg, error_code: testErrCode},
@@ -353,6 +354,7 @@ describe('anonymous auth', () => {
   beforeEach(() => {
     let count = 0;
     fetchMock.restore();
+    fetchMock.delete(SESSION_URL, 204);
     fetchMock.mock(`begin:${ANON_AUTH_URL}`, (url, opts) => {
       const parsed = new URL(url, '', true);
       const device = parsed.query ? parsed.query.device : null;
@@ -388,6 +390,7 @@ describe('custom auth', () => {
   beforeEach(() => {
     let count = 0;
     fetchMock.restore();
+    fetchMock.delete(SESSION_URL, 204);
     fetchMock.mock(`begin:${CUSTOM_AUTH_URL}`, (url, opts) => {
       const parsed = new URL(url, '', true);
       const device = parsed.query ? parsed.query.device : null;
@@ -448,6 +451,7 @@ describe('api key auth/logout', () => {
   beforeEach(() => {
     let count = 0;
     fetchMock.restore();
+    fetchMock.delete(SESSION_URL, 204);
     fetchMock.post(APIKEY_AUTH_URL, (url, opts) => {
       if (validAPIKeys.indexOf(JSON.parse(opts.body).key) >= 0) {
         return {
@@ -504,6 +508,7 @@ describe('login/logout', () => {
       beforeEach(() => {
         fetchMock.restore();
         fetchMock.get(PROFILE_URL, () => sampleProfile);
+        fetchMock.delete(SESSION_URL, 204);
         fetchMock.post(LOCALAUTH_URL, {
           user_id: hexStr,
           refresh_token: testOriginalRefreshToken,
@@ -616,6 +621,7 @@ describe('token refresh', () => {
       ++refreshCount;
       return {access_token: testUnexpiredAccessToken};
     });
+    fetchMock.delete(SESSION_URL, 204);
   });
 
   it('fetches a new access token if the remote server says the stored token is expired', async() => {
@@ -687,7 +693,7 @@ describe('client options', () => {
     fetchMock.post('https://stitch2.mongodb.com/api/client/v2.0/app/testapp/functions/call', (url, opts) => {
       return {x: {'$oid': hexStr}};
     });
-    fetchMock.delete(SESSION_URL, {});
+    fetchMock.delete(SESSION_URL, 204);
     fetchMock.post(FUNCTION_CALL_URL, () => {
       return JSON.stringify({x: {'$oid': hexStr}});
     });
@@ -730,6 +736,7 @@ describe('function execution', () => {
           fetchMock.post(FUNCTION_CALL_URL, () => {
             return JSON.stringify({x: {'$oid': hexStr}});
           });
+          fetchMock.delete(SESSION_URL, 204);
         });
 
         it('should decode extended json from function responses', async() => {
@@ -750,6 +757,7 @@ describe('function execution', () => {
             requestArg = arg1;
             return {x: {'$oid': hexStr}};
           });
+          fetchMock.delete(SESSION_URL, 204);
         });
 
         it('should encode objects to extended json for outgoing function request body', async() => {
@@ -772,6 +780,7 @@ describe('function execution', () => {
               status: 400
             };
           });
+          fetchMock.delete(SESSION_URL, 204);
         });
 
         it('promise should be rejected', async() => {

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@ global.Buffer = global.Buffer || require('buffer').Buffer;
 
 const hexStr = '5899445b275d3ebe8f2ab8c0';
 const mockDeviceId = '8773934448abcdef12345678';
+const groupId = '5c018152c7e793e2d9d3ef74';
 
 const sampleProfile = {
   user_id: '8a15d6d20584297fa336becf',

--- a/test/testutil.js
+++ b/test/testutil.js
@@ -30,7 +30,7 @@ export const buildClientTestHarness = async(apiKey, groupId, serverUrl) => {
   return harness;
 };
 
-export const randomString = (length=5) => {
+export const randomString = (length = 5) => {
   const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
   let result = '';
   for (let i = length; i > 0; i -= 1) {


### PR DESCRIPTION
Things still failing on Evergreen as of [this build](https://evergreen.mongodb.com/task/stitch_js_sdk_3.0_linux_64_run_tests_patch_d309cecb4a5ad12b9aaa714903b5a8ea9826edc5_5c05796f2fbabe111110e046_18_12_03_18_43_59):
- `test/test.js`
- `test/auth.test.js`
- `test/storage.test.js`
- ~`test/client/oauth.test.js`~