### PR TITLE
STITCH-2325 fix bug where decoded HTTP response headers contained undefined entry

### DIFF
--- a/packages/browser/services/http/__tests__/HttpServiceClientIntTests.ts
+++ b/packages/browser/services/http/__tests__/HttpServiceClientIntTests.ts
@@ -130,6 +130,9 @@ describe("HttpServiceClient", () => {
       expect(response.contentLength).toBeGreaterThanOrEqual(300);
       expect(response.contentLength).toBeLessThanOrEqual(500);
       expect(response.body).toBeDefined();
+      expect(response.headers['Content-Type'].length).toEqual(1);
+      expect(response.headers['Content-Type'][0]).toEqual('application/json');
+      
       const dataDoc = EJSON.parse(String(response.body!!), { relaxed: true });
       expect(body).toEqual(dataDoc.data);
       const headersDoc = dataDoc.headers;

--- a/packages/core/services/http/__tests__/internal/CoreHttpServiceClientUnitTests.ts
+++ b/packages/core/services/http/__tests__/internal/CoreHttpServiceClientUnitTests.ts
@@ -36,7 +36,7 @@ describe("CoreHttpServiceClient", () => {
     const expectedBody = "hello world!";
     const expectedCookies = {};
     const expectedForm = {};
-    const expectedHeaders = {};
+    const expectedHeaders = { 'foo': ['bar'] };
 
     const request = new HttpRequest.Builder()
       .withUrl(expectedUrl)

--- a/packages/core/services/http/src/internal/ResultDecoders.ts
+++ b/packages/core/services/http/src/internal/ResultDecoders.ts
@@ -48,7 +48,7 @@ class HttpResponseDecoder implements Decoder<HttpResponse> {
       Object.keys(headersDoc).forEach(headerKey => {
         const headerValue = headersDoc[headerKey];
         const valuesArr = headerValue;
-        const values = new Array(valuesArr.length);
+        const values = new Array();
         for (const value of valuesArr) {
           values.push(value);
         }

--- a/packages/react-native/services/http/__tests__/HttpServiceClientIntTests.ts
+++ b/packages/react-native/services/http/__tests__/HttpServiceClientIntTests.ts
@@ -130,7 +130,6 @@ describe("HttpServiceClient", () => {
       expect(response.contentLength).toBeGreaterThanOrEqual(300);
       expect(response.contentLength).toBeLessThanOrEqual(500);
       expect(response.body).toBeDefined();
-      expect(response.headers).toBeDefined();
       expect(response.headers['Content-Type'].length).toEqual(1);
       expect(response.headers['Content-Type'][0]).toEqual('application/json');
       

--- a/packages/react-native/services/http/__tests__/HttpServiceClientIntTests.ts
+++ b/packages/react-native/services/http/__tests__/HttpServiceClientIntTests.ts
@@ -130,6 +130,10 @@ describe("HttpServiceClient", () => {
       expect(response.contentLength).toBeGreaterThanOrEqual(300);
       expect(response.contentLength).toBeLessThanOrEqual(500);
       expect(response.body).toBeDefined();
+      expect(response.headers).toBeDefined();
+      expect(response.headers['Content-Type'].length).toEqual(1);
+      expect(response.headers['Content-Type'][0]).toEqual('application/json');
+      
       const dataDoc = EJSON.parse(String(response.body!!), { relaxed: true });
       expect(body).toEqual(dataDoc.data);
       const headersDoc = dataDoc.headers;

--- a/packages/server/services/http/__tests__/HttpServiceClientIntTests.ts
+++ b/packages/server/services/http/__tests__/HttpServiceClientIntTests.ts
@@ -130,6 +130,9 @@ describe("HttpServiceClient", () => {
       expect(response.contentLength).toBeGreaterThanOrEqual(300);
       expect(response.contentLength).toBeLessThanOrEqual(500);
       expect(response.body).toBeDefined();
+      expect(response.headers['Content-Type'].length).toEqual(1);
+      expect(response.headers['Content-Type'][0]).toEqual('application/json');
+
       const dataDoc = EJSON.parse(String(response.body!!), { relaxed: true });
       expect(body).toEqual(dataDoc.data);
       const headersDoc = dataDoc.headers;


### PR DESCRIPTION
should be pretty straightforward, fixed a bug where headers decoder was being preallocated with undefined entries that were never filled