### PR TITLE
DOCSP-3942 Improve Authentication flow in SDK docs

### DIFF
--- a/contrib/stage_docs.sh
+++ b/contrib/stage_docs.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -ex
+
+USER=`whoami`
+
+npm run docs
+
+if ! which aws; then
+    echo "aws CLI not found. see: https://docs.aws.amazon.com/cli/latest/userguide/installing.html"
+    exit 1
+fi
+
+BRANCH_NAME=`git branch | grep -e "^*" | cut -d' ' -f 2`
+
+USER_BRANCH="${USER}/${BRANCH_NAME}"
+
+aws s3 cp ../docs-browser s3://docs-mongodb-org-staging/stitch/"$USER_BRANCH"/sdk/js/ --recursive --acl public-read
+aws s3 cp ../docs-server s3://docs-mongodb-org-staging/stitch/"$USER_BRANCH"/sdk/js-server/ --recursive --acl public-read
+aws s3 cp ../docs-react-native s3://docs-mongodb-org-staging/stitch/"$USER_BRANCH"/sdk/react-native/ --recursive --acl public-read
+
+echo
+echo "Staged URLs:"
+echo "  https://docs-mongodbcom-staging.corp.mongodb.com/stitch/$USER_BRANCH/sdk/js/index.html"
+echo "  https://docs-mongodbcom-staging.corp.mongodb.com/stitch/$USER_BRANCH/sdk/js-server/index.html"
+echo "  https://docs-mongodbcom-staging.corp.mongodb.com/stitch/$USER_BRANCH/sdk/react-native/index.html"

--- a/packages/browser/core/src/core/Stitch.ts
+++ b/packages/browser/core/src/core/Stitch.ts
@@ -27,12 +27,23 @@ const DEFAULT_BASE_URL = "https://stitch.mongodb.com";
 const appClients: { [key: string]: StitchAppClientImpl } = {};
 
 /**
- * Singleton class with static utility functions for initializing the MongoDB 
- * Stitch Browser SDK, and for retrieving a {@link StitchAppClient}.
+ * Singleton class with static utility functions for initializing a [[StitchAppClient]].
+ *
+ * Typically, the [[Stitch.initializeDefaultAppClient]] method is all you need 
+ * to instantiate the client:
+ * 
+ * ```
+ * const client = Stitch.initializeDefaultAppClient('your-stitch-app-id')
+ * ```
+ *
+ * For custom configurations, see [[Stitch.initializeAppClient]] and [[StitchAppClientConfiguration]].
+ *
+ * ### See also
+ * - [[StitchAppClient]]
  */
 export default class Stitch {
   /**
-   * Retrieves the default StitchAppClient associated with the application.
+   * Retrieves the default [[StitchAppClient]] associated with the application.
    */
   public static get defaultAppClient(): StitchAppClient {
     if (Stitch.defaultClientAppId === undefined) {
@@ -42,7 +53,7 @@ export default class Stitch {
   }
 
   /**
-   * Retrieves the StitchAppClient associated with the specified client app id.
+   * Retrieves the [[StitchAppClient]] associated with the specified client app id.
    * @param clientAppId The client app id of the desired app client.
    */
   public static getAppClient(clientAppId: string): StitchAppClient {
@@ -55,8 +66,8 @@ export default class Stitch {
   }
 
   /**
-   * Returns whether or not a StitchAppClient has been initialized for the
-   * specified clientAppId
+   * Returns whether or not a [[StitchAppClient]] has been initialized for the
+   * specified clientAppId.
    * 
    * @param clientAppId The client app id to check for.
    */
@@ -65,7 +76,7 @@ export default class Stitch {
   }
 
   /**
-   * Initializes the default StitchAppClient associated with the application.
+   * Initializes the default [[StitchAppClient]] associated with the application.
    * 
    * @param clientAppId The desired clientAppId for the client.
    * @param config Additional configuration options (optional).
@@ -90,11 +101,11 @@ export default class Stitch {
   }
 
   /**
-   * Initializes a new, non-default StitchAppClient associated with the 
+   * Initializes a new, non-default [[StitchAppClient]] associated with the 
    * application.
    * 
    * @param clientAppId The desired clientAppId for the client.
-   * @param config Additional configuration options (optional).
+   * @param config Additional [[StitchAppClientConfiguration]] options (optional).
    */
   public static initializeAppClient(
     clientAppId: string,

--- a/packages/browser/core/src/core/StitchAppClient.ts
+++ b/packages/browser/core/src/core/StitchAppClient.ts
@@ -20,18 +20,36 @@ import StitchServiceClient from "../services/StitchServiceClient";
 import StitchAuth from "./auth/StitchAuth";
 
 /**
- * The fundamental set of methods for communicating with a MongoDB Stitch 
- * application. Contains methods for executing Stitch functions and retrieving 
- * clients for Stitch services, and contains a `StitchAuth` object to manage 
- * the authentication state of the client. An implementation can be 
- * instantiated using the `Stitch` utility class.
+ * The StitchAppClient is the interface to a MongoDB Stitch App backend.
+ *
+ * It is created by the [[Stitch]] singleton.
+ *
+ * The StitchAppClient holds a [[StitchAuth]] object for managing the login state of the client.
+ *
+ * It provides clients for [Stitch Services](https://docs.mongodb.com/stitch/services/) including
+ * the [[RemoteMongoClient]] for database and collection access.
+ *
+ * Finally, the StitchAppClient can execute [Stitch Functions](https://docs.mongodb.com/stitch/functions/).
+ *
+ * ### Example
+ * ```
+ * import { Stitch } from "mongodb-stitch-browser-sdk"
+ * 
+ * const client = Stitch.initializeDefaultAppClient('example-stitch-app-id')
+ * ```
+ * 
+ * ### See also
+ * - [[Stitch]]
+ * - [[StitchAuth]]
+ * - [[RemoteMongoClient]]
+ * - [Stitch Functions](https://docs.mongodb.com/stitch/functions/)
  */
 export default interface StitchAppClient {
   /**
-   * The {@link StitchAuth} object representing the authentication state of 
-   * this client. Includes methods for logging in and logging out.
+   * The [[StitchAuth]] object representing the login state of this client.
+   * Includes methods for logging in and logging out.
    *
-   * Authentication state can be persisted beyond the lifetime of a browser 
+   * Login state can be persisted beyond the lifetime of a browser 
    * session. A StitchAppClient retrieved from the `Stitch` singleton may or 
    * may not be already authenticated when first initialized.
    */

--- a/packages/browser/core/src/core/auth/StitchAuth.ts
+++ b/packages/browser/core/src/core/auth/StitchAuth.ts
@@ -22,25 +22,50 @@ import StitchAuthListener from "./StitchAuthListener";
 import StitchUser from "./StitchUser";
 
 /**
- * A set of methods for retrieving or modifying the authentication state of a 
- * {@link StitchAppClient}. An implementation can be instantiated with a 
- * {@link StitchAppClient} instance.
+ * StitchAuth represents and controls the login state of a [[StitchAppClient]]. 
+ *
+ * Login is required for most Stitch functionality. Depending on which
+ * [Authentication Provider](https://docs.mongodb.com/stitch/authentication/)
+ * you are using, use [[loginWithCredential]] or [[loginWithRedirect]] to log in.
+ *
+ * Once logged in, [[StitchAuth.user]] is a [[StitchUser]] object that can be examined for 
+ * user profile and other information.
+ * 
+ * Login state can persist across browser sessions. Therefore, a StitchAppClient's
+ * StitchAuth instance may already contain login information upon initialization.
+ * 
+ * In the case of OAuth2 authentication providers, StitchAuth may also initialize with
+ * the result of a previous session's request to [[loginWithRedirect]]. The redirect
+ * result can be checked with [[hasRedirectResult]] and handled with [[handleRedirectResult]].
+ *
+ * To log out, use [[logout]].
+ *
+ * ### Examples
+ *
+ * For an example of [[loginWithCredential]], see [Anonymous Authentication](https://docs.mongodb.com/stitch/authentication/anonymous/).
+ *
+ * For an example of [[loginWithRedirect]], see [Facebook Authentication](https://docs.mongodb.com/stitch/authentication/facebook/).
+ * 
+ * ### See also
+ * - [Users](https://docs.mongodb.com/stitch/users/)
+ * - [Authentication](https://docs.mongodb.com/stitch/authentication/)
+ * - [[StitchAppClient]]
+ * - [[StitchUser]]
  */
 export default interface StitchAuth {
   /**
-   * Whether or not the client containing this `StitchAuth` object is currently 
-   * authenticated.
+   * Whether or not the [[StitchAppClient]] containing this StitchAuth object 
+   * is currently logged in.
    */
   isLoggedIn: boolean;
 
   /**
-   * A {@link StitchUser} object representing the user that the client is 
-   * currently authenticated as. `undefined` if the client is not currently 
-   * authenticated.
+   * A [[StitchUser]] object representing who the client is currently logged in as,
+   * or `undefined` if the client is not currently logged in.
    */
   user?: StitchUser;
 
-  /**
+  /** @hidden
    * Retrieves the authentication provider client for the authentication 
    * provider associated with the specified factory.
    * 
@@ -50,7 +75,7 @@ export default interface StitchAuth {
     factory: AuthProviderClientFactory<ClientT>
   ): ClientT;
 
-  /**
+  /** @hidden
    * Retrieves the authentication provider client for the authentication 
    * provider associated with the specified factory and auth provider name.
    * 
@@ -62,36 +87,46 @@ export default interface StitchAuth {
   ): T;
 
   /**
-   * Authenticates the client as a MongoDB Stitch user using the provided 
-   * {@link StitchCredential}.
+   * Logs in as a [[StitchUser]] using the provided [[StitchCredential]].
    * 
-   * @param credential The credential to use when logging in.
+   * For an example of the most simple form of authentication, see
+   * [Anonymous Authentication](https://docs.mongodb.com/stitch/authentication/anonymous/).
+   *
+   * For another example, see [Email/Password Authentication](https://docs.mongodb.com/stitch/authentication/userpass/).
+   *
+   * @param credential The [[StitchCredential]] to use when logging in.
    */
   loginWithCredential(credential: StitchCredential): Promise<StitchUser>;
 
   /**
    * Authenticates the client as a MongoDB Stitch user using the provided 
-   * {@link StitchRedirectCredential}. This method will redirect the user to
-   * an OAuth2 login page where the login is handled externally. That external
-   * page will redirect the user back to the page specified in the redirect
-   * credential. To complete the login, that page will need to handle the 
-   * redirect by calling {@link handleRedirectResult()}.
+   * [[StitchRedirectCredential]].
    * 
-   * @param credential The credential to use when logging in.
+   * This method will redirect the user to an OAuth2 login page where the 
+   * login is handled externally. That external page will redirect the user 
+   * back to the page specified in the redirect credential. To complete 
+   * the login, that page will need to handle the redirect by calling
+   * [[handleRedirectResult]].
+   *
+   * For usage examples, see [Facebook Authentication](https://docs.mongodb.com/stitch/authentication/facebook/)
+   * and [Google Authentication](https://docs.mongodb.com/stitch/authentication/google/).
+   * 
+   * @param credential The [[StitchRedirectCredential]] to use when logging in.
    */
   loginWithRedirect(credential: StitchRedirectCredential): void;
 
   /**
-   * Checks whether or not the page was just redirected to from a login process
-   * initiated by {@link loginWithRedirect()}. Call this method before calling
-   * {@link handleRedirectResult} if you want to avoid errors.
+   * Checks whether or not an external login process previously started by [[loginWithRedirect]]
+   * has redirected the user to this page.
+   * 
+   * Stitch will have this information available right after initialization.
+   * 
+   * Call this method before calling [[handleRedirectResult]] if you want to avoid errors.
    */
   hasRedirectResult(): boolean;
 
   /**
-   * Handles a redirect by completing the login response and authenticating the
-   * client. Should be called by the redirect handling page that 
-   * {@link loginWithRedirect()} redirects to.
+   * If [[hasRedirectResult]] is true, completes the OAuth2 login previously started by [[loginWithRedirect]].
    */
   handleRedirectResult(): Promise<StitchUser>;
 
@@ -102,7 +137,7 @@ export default interface StitchAuth {
   logout(): Promise<void>;
 
   /**
-   * Registers a {@link StitchAuthListener} with the client.
+   * Registers a [[StitchAuthListener]] with the client.
    * @param listener The listener to be triggered when an authentication event
    * occurs on this auth object.
    */

--- a/packages/browser/core/src/core/auth/StitchUser.ts
+++ b/packages/browser/core/src/core/auth/StitchUser.ts
@@ -23,9 +23,15 @@ import {
 import StitchRedirectCredential from "./providers/StitchRedirectCredential";
 
 /**
- * A user that a {@link StitchAppClient} is currently authenticated as.
- * Can be retrieved from a {@link StitchAuth} or from the result of certain 
- * methods.
+ * The StitchUser represents the currently logged-in user of the [[StitchAppClient]].
+ * 
+ * This can be retrieved from [[StitchAuth]] or from the result of certain methods
+ * such as [[StitchAuth.loginWithCredential]] or [[StitchAuth.handleRedirectResult]].
+ *
+ * ### See also
+ * - [[StitchAuth]]
+ * - [[StitchCredential]]
+ * - [[StitchRedirectCredential]]
  */
 export default interface StitchUser extends CoreStitchUser {
   /**

--- a/packages/browser/core/src/core/auth/providers/StitchRedirectCredential.ts
+++ b/packages/browser/core/src/core/auth/providers/StitchRedirectCredential.ts
@@ -15,9 +15,19 @@
  */
 
 /**
- * A credential which can be used with {@link StitchAuth.loginWithRedirect} to
- * login via OAuth. Do not use this credential directly, use one of its 
- * implementations.
+ * StitchRedirectCredential is an interface for [OAuth2](https://en.wikipedia.org/wiki/OAuth)
+ * login flow credentials.
+ * 
+ * Pass implementations to [[StitchAuth.loginWithRedirect]] to log in as a [[StitchUser]].
+ * 
+ * Each [Authentication Provider](https://docs.mongodb.com/stitch/authentication/)
+ * in MongoDB Stitch provides a [[StitchCredential]] or StitchRedirectCredential
+ * implementation. See **Implemented by** below for a list of implementations.
+ *
+ * ### See also
+ * - [[StitchAuth]]
+ * - [[StitchAuth.loginWithRedirect]] 
+ * - [[StitchCredential]]
  */
 export default interface StitchRedirectCredential {
   readonly providerName: string;

--- a/packages/browser/services/mongodb-remote/src/RemoteMongoClient.ts
+++ b/packages/browser/services/mongodb-remote/src/RemoteMongoClient.ts
@@ -24,15 +24,31 @@ import RemoteMongoClientImpl from "./internal/RemoteMongoClientImpl";
 import RemoteMongoDatabase from "./RemoteMongoDatabase";
 
 /**
- * A client which can be used to get database and collection objects which can 
- * be used to interact with MongoDB data via the Stitch MongoDB service.
+ * The RemoteMongoClient can be used to get database and collection objects
+ * for interacting with MongoDB data via the Stitch MongoDB service.
+ *
+ * Service clients are created with [[StitchAppClient.getServiceClient]], passing
+ * [[RemoteMongoClient.factory]] and the Stitch Service Name found under Stitch 
+ * Cluster Configuration ("mongodb-atlas" by default).
+ *
+ * ```
+ * const stitchClient = Stitch.initializeDefaultAppClient('your-stitch-app-id')
+ * const mongoClient = stitchClient.getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
+ * ```
+ *
+ * Once the RemoteMongoClient is instantiated, use the [[db]] method to access databases.
+ *
+ * Note: The client needs to log in (at least anonymously) to use the database. See [[StitchAuth]].
+ *
+ * ### See also
+ * - [[StitchAppClient]]
  */
 export interface RemoteMongoClient {
   /**
-   * Gets a {@link RemoteMongoDatabase} instance for the given database name.
+   * Gets a [[RemoteMongoDatabase]] instance for the given database name.
    *
    * @param name the name of the database to retrieve
-   * @return a {@code RemoteMongoDatabase} representing the specified database
+   * @return a [[RemoteMongoDatabase]] representing the specified database
    */
   db(name: string): RemoteMongoDatabase;
 }

--- a/packages/core/sdk/src/auth/StitchCredential.ts
+++ b/packages/core/sdk/src/auth/StitchCredential.ts
@@ -17,9 +17,18 @@
 import ProviderCapabilities from "./ProviderCapabilities";
 
 /**
- * A credential which can be used to log in as a Stitch user. There is an implementation for each authentication
- * provider available in MongoDB Stitch. These implementations can be generated using an authentication provider
- * client.
+ * StitchCredential is an interface for simple login flow credentials.
+ * 
+ * Pass implementations to [[StitchAuth.loginWithCredential]] to log in as a [[StitchUser]].
+ * 
+ * Each [Authentication Provider](https://docs.mongodb.com/stitch/authentication/)
+ * in MongoDB Stitch provides a StitchCredential or [[StitchRedirectCredential]]
+ * implementation. See **Implemented by** below for a list of implementations.
+ *
+ * ### See also
+ * - [[StitchAuth]]
+ * - [[StitchAuth.loginWithCredential]] 
+ * - [[StitchRedirectCredential]]
  */
 export default interface StitchCredential {
   /**

--- a/packages/core/sdk/src/auth/providers/anonymous/AnonymousCredential.ts
+++ b/packages/core/sdk/src/auth/providers/anonymous/AnonymousCredential.ts
@@ -19,9 +19,22 @@ import StitchCredential from "../../StitchCredential";
 import AnonymousAuthProvider from "./AnonymousAuthProvider";
 
 /**
- * A credential which can be used to log in as a Stitch user
- * using the anonymous authentication provider.
- */
+ * The AnonymousCredential is a [[StitchCredential]] that logs in
+ * using the [Anonymous Authentication Provider](https://docs.mongodb.com/stitch/authentication/anonymous/).
+ *
+ * ### Example
+ * ```
+ * const client = Stitch.initializeDefaultAppClient('example-app-id')
+ * client.auth.loginWithCredential(new AnonymousCredential())
+ *   .then(user => {
+ *     // Now logged in anonymously
+ *   })
+ *   .catch(console.error)
+ * ```
+ *
+ * ### See also
+ * - [[StitchAuth.loginWithCredential]] 
+*/
 export default class AnonymousCredential implements StitchCredential {
   /**
    * The name of the provider for this credential.

--- a/packages/core/sdk/src/auth/providers/facebook/FacebookCredential.ts
+++ b/packages/core/sdk/src/auth/providers/facebook/FacebookCredential.ts
@@ -22,6 +22,7 @@ enum Fields {
   ACCESS_TOKEN = "accessToken"
 }
 
+/** @hidden */
 export default class FacebookCredential implements StitchCredential {
   public readonly providerName: string;
   public readonly providerType = FacebookAuthProvider.TYPE;

--- a/packages/core/sdk/src/auth/providers/google/GoogleCredential.ts
+++ b/packages/core/sdk/src/auth/providers/google/GoogleCredential.ts
@@ -22,7 +22,7 @@ enum Fields {
   AUTH_CODE = "authCode"
 }
 
-/**
+/** @hidden
  * A credential which can be used to log in as a Stitch user
  * using the Google authentication provider.
  */


### PR DESCRIPTION
- Adds links to pages related to authentication
- Clarifies purpose of some classes from a user perspective
- Hides non-redirect GoogleCredential and FacebookCredential,
as their auth providers are also hidden

Staged docs (start at StitchAppClient and navigate the auth flow):
https://docs-mongodbcom-staging.corp.mongodb.com/stitch/bush/docsp-auth/sdk/js/index.html