### PR TITLE
DOCSP-3936 Push docs to docs.mongodb.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The official [MongoDB Stitch](https://stitch.mongodb.com/) SDK for JavaScript/Ty
 - [Discussion](#discussion)
 
 ## Documentation
-* [Browser SDK API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js/docs/4.1.0/index.html)
-* [Server (Node.js) SDK API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js-server/docs/4.1.0/index.html)
-* [React Native SDK API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js-react-native/docs/4.1.0/index.html)
+* [Browser SDK API/Typedoc Documentation](https://docs.mongodb.com/stitch-sdks/js/4.1.0/index.html)
+* [Server (Node.js) SDK API/Typedoc Documentation](https://docs.mongodb.com/stitch-sdks/js-server/4.1.0/index.html)
+* [React Native SDK API/Typedoc Documentation](https://docs.mongodb.com/stitch-sdks/js-react-native/4.1.0/index.html)
 * [MongoDB Stitch Documentation](https://docs.mongodb.com/stitch/)
 
 ## Discussion

--- a/contrib/publish_docs.sh
+++ b/contrib/publish_docs.sh
@@ -18,20 +18,20 @@ fi
 
 if [ -z "$VERSION_QUALIFIER" ]; then
 	# Publish to MAJOR, MAJOR.MINOR
-	aws s3 cp ../docs-browser s3://stitch-sdks/js/docs/$VERSION_MAJOR --recursive --acl public-read
-	aws s3 cp ../docs-browser s3://stitch-sdks/js/docs/$VERSION_MAJOR.$VERSION_MINOR --recursive --acl public-read
-	aws s3 cp ../docs-server s3://stitch-sdks/js-server/docs/$VERSION_MAJOR --recursive --acl public-read
-	aws s3 cp ../docs-server s3://stitch-sdks/js-server/docs/$VERSION_MAJOR.$VERSION_MINOR --recursive --acl public-read
-	aws s3 cp ../docs-react-native s3://stitch-sdks/js-react-native/docs/$VERSION_MAJOR --recursive --acl public-read
-	aws s3 cp ../docs-react-native s3://stitch-sdks/js-react-native/docs/$VERSION_MAJOR.$VERSION_MINOR --recursive --acl public-read
+	aws s3 cp ../docs-browser s3://stitch-sdks/stitch-sdks/js/$VERSION_MAJOR --recursive --acl public-read
+	aws s3 cp ../docs-browser s3://stitch-sdks/stitch-sdks/js/$VERSION_MAJOR.$VERSION_MINOR --recursive --acl public-read
+	aws s3 cp ../docs-server s3://stitch-sdks/stitch-sdks/js-server/$VERSION_MAJOR --recursive --acl public-read
+	aws s3 cp ../docs-server s3://stitch-sdks/stitch-sdks/js-server/$VERSION_MAJOR.$VERSION_MINOR --recursive --acl public-read
+	aws s3 cp ../docs-react-native s3://stitch-sdks/stitch-sdks/js-react-native/$VERSION_MAJOR --recursive --acl public-read
+	aws s3 cp ../docs-react-native s3://stitch-sdks/stitch-sdks/js-react-native/$VERSION_MAJOR.$VERSION_MINOR --recursive --acl public-read
 fi
 
 # Publish to full version
-aws s3 cp ../docs-browser s3://stitch-sdks/js/docs/$VERSION --recursive --acl public-read
-aws s3 cp ../docs-server s3://stitch-sdks/js-server/docs/$VERSION --recursive --acl public-read
-aws s3 cp ../docs-react-native s3://stitch-sdks/js-react-native/docs/$VERSION --recursive --acl public-read
+aws s3 cp ../docs-browser s3://stitch-sdks/stitch-sdks/js/$VERSION --recursive --acl public-read
+aws s3 cp ../docs-server s3://stitch-sdks/stitch-sdks/js-server/$VERSION --recursive --acl public-read
+aws s3 cp ../docs-react-native s3://stitch-sdks/stitch-sdks/js-react-native/$VERSION --recursive --acl public-read
 
 BRANCH_NAME=`git branch | grep -e "^*" | cut -d' ' -f 2`
-aws s3 cp ../docs-browser s3://stitch-sdks/js/docs/branch/$BRANCH_NAME --recursive --acl public-read
-aws s3 cp ../docs-server s3://stitch-sdks/js-server/docs/branch/$BRANCH_NAME --recursive --acl public-read
-aws s3 cp ../docs-react-native s3://stitch-sdks/js-react-native/docs/branch/$BRANCH_NAME --recursive --acl public-read
+aws s3 cp ../docs-browser s3://stitch-sdks/stitch-sdks/js/branch/$BRANCH_NAME --recursive --acl public-read
+aws s3 cp ../docs-server s3://stitch-sdks/stitch-sdks/js-server/branch/$BRANCH_NAME --recursive --acl public-read
+aws s3 cp ../docs-react-native s3://stitch-sdks/stitch-sdks/js-react-native/branch/$BRANCH_NAME --recursive --acl public-read

--- a/packages/browser/sdk/README.md
+++ b/packages/browser/sdk/README.md
@@ -11,7 +11,7 @@ The official [MongoDB Stitch](https://stitch.mongodb.com/) Browser SDK for JavaS
 - [Example Usage](#example-usage)
 
 ## Documentation
-* [API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js/docs/4.1.0/index.html)
+* [API/Typedoc Documentation](https://docs.mongodb.com/stitch-sdks/js/4.1.0/index.html)
 * [MongoDB Stitch Documentation](https://docs.mongodb.com/stitch/)
 
 ## Discussion

--- a/packages/react-native/sdk/README.md
+++ b/packages/react-native/sdk/README.md
@@ -11,7 +11,7 @@ The official [MongoDB Stitch](https://stitch.mongodb.com/) React Native SDK for 
 - [Example Usage](#example-usage)
 
 ## Documentation
-* [API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js-react-native/docs/4.1.0/index.html)
+* [API/Typedoc Documentation](https://docs.mongodb.com/stitch-sdks/js-react-native/4.1.0/index.html)
 * [MongoDB Stitch Documentation](https://docs.mongodb.com/stitch/)
 
 ## Discussion

--- a/packages/server/sdk/README.md
+++ b/packages/server/sdk/README.md
@@ -11,7 +11,7 @@ The official [MongoDB Stitch](https://stitch.mongodb.com/) Server SDK for JavaSc
 - [Example Usage](#example-usage)
 
 ## Documentation
-* [API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js-server/docs/4.1.0/index.html)
+* [API/Typedoc Documentation](https://docs.mongodb.com/stitch-sdks/js-server/4.1.0/index.html)
 * [MongoDB Stitch Documentation](https://docs.mongodb.com/stitch/)
 
 ## Discussion


### PR DESCRIPTION
This updates the destination to a stitch-sdks subdirectory on the
existing bucket so that docs.mongodb.com/stitch-sdks can find it.
(Not sure, this was specifically required by techops.)

Removes the /docs/ part which is arguably redundant now that it is
hosted on docs.mongodb.com.

Also updates the READMEs for the new docs URL. Please publish
the docs and check that the new URL works.