### PR TITLE
STITCH-2341 Export BSON library with SDKs at top level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,4 @@
 {
-	"name": "stitch-js-sdk",
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
@@ -23,26 +22,23 @@
 		},
 		"@types/detect-browser": {
 			"version": "2.0.1",
-			"resolved": "http://registry.npmjs.org/@types/detect-browser/-/detect-browser-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/@types/detect-browser/-/detect-browser-2.0.1.tgz",
 			"integrity": "sha512-n9jH0zq0DGOlu/B9tSpK+DKwaW9uozF96hy3zYibvxVqQDX5KOJJn6qns/G+k3UwfEQVYZuV3Rz+Z2fXMQ0ang=="
 		},
 		"@types/estree": {
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-			"dev": true
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
 		},
 		"@types/events": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
-			"dev": true
+			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
 		},
 		"@types/fs-extra": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
 			"integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -51,7 +47,6 @@
 			"version": "5.0.35",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
 			"integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
-			"dev": true,
 			"requires": {
 				"@types/events": "*",
 				"@types/minimatch": "*",
@@ -61,26 +56,22 @@
 		"@types/handlebars": {
 			"version": "4.0.36",
 			"resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.36.tgz",
-			"integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ==",
-			"dev": true
+			"integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ=="
 		},
 		"@types/highlight.js": {
 			"version": "9.12.2",
 			"resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
-			"integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
-			"dev": true
+			"integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ=="
 		},
 		"@types/jest": {
 			"version": "23.1.5",
 			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.1.5.tgz",
-			"integrity": "sha512-GlN74UAcT2i+G4BzVVI/aHip0HDXZaiY11VEjHzAz74+dB3hIeM5lJmnnZx4acxxinK9lT+uEH1Vsa5aWj6w4Q==",
-			"dev": true
+			"integrity": "sha512-GlN74UAcT2i+G4BzVVI/aHip0HDXZaiY11VEjHzAz74+dB3hIeM5lJmnnZx4acxxinK9lT+uEH1Vsa5aWj6w4Q=="
 		},
 		"@types/jsonwebtoken": {
 			"version": "7.2.8",
 			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
 			"integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -88,32 +79,27 @@
 		"@types/lodash": {
 			"version": "4.14.104",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
-			"integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ==",
-			"dev": true
+			"integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ=="
 		},
 		"@types/marked": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.3.0.tgz",
-			"integrity": "sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg==",
-			"dev": true
+			"integrity": "sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg=="
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-			"dev": true
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
 			"version": "10.5.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.2.tgz",
-			"integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q==",
-			"dev": true
+			"integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q=="
 		},
 		"@types/shelljs": {
 			"version": "0.7.8",
 			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.8.tgz",
 			"integrity": "sha512-M2giRw93PxKS7YjU6GZjtdV9HASdB7TWqizBXe4Ju7AqbKlWvTr0gNO92XH56D/gMxqD/jNHLNfC5hA34yGqrQ==",
-			"dev": true,
 			"requires": {
 				"@types/glob": "*",
 				"@types/node": "*"
@@ -353,7 +339,6 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
 			"integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
-			"dev": true,
 			"requires": {
 				"jsonparse": "^1.2.0",
 				"through": ">=2.2.7 <3"
@@ -364,11 +349,16 @@
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
 			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
 		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"optional": true
+		},
 		"abstract-leveldown": {
 			"version": "0.12.4",
 			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
 			"integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-			"dev": true,
 			"requires": {
 				"xtend": "~3.0.0"
 			},
@@ -376,8 +366,7 @@
 				"xtend": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-					"integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-					"dev": true
+					"integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
 				}
 			}
 		},
@@ -413,9 +402,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.0.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+					"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
 				}
 			}
 		},
@@ -427,13 +416,12 @@
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
-			"dev": true
+			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo="
 		},
 		"ajv": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-			"integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+			"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -747,7 +735,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
 			"integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
-			"dev": true,
 			"requires": {
 				"buffer-equal": "^1.0.0"
 			}
@@ -769,7 +756,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -803,7 +789,7 @@
 		},
 		"array-equal": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
 		"array-filter": {
@@ -817,15 +803,14 @@
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
 		},
 		"array-flatten": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
 		},
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-			"dev": true
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
 		},
 		"array-includes": {
 			"version": "3.0.3",
@@ -907,7 +892,7 @@
 				},
 				"util": {
 					"version": "0.10.3",
-					"resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 					"requires": {
 						"inherits": "2.0.1"
@@ -987,7 +972,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -999,7 +984,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -1215,7 +1200,7 @@
 		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.6",
-			"resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
@@ -1231,17 +1216,17 @@
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
 			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
 			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
 			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1730,9 +1715,9 @@
 			}
 		},
 		"big.js": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
 		},
 		"binary-extensions": {
 			"version": "1.12.0",
@@ -1743,7 +1728,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
 			"integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "~1.0.26"
 			},
@@ -1751,14 +1735,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -1769,8 +1751,7 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -1896,7 +1877,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browserify-fs/-/browserify-fs-1.0.0.tgz",
 			"integrity": "sha1-8HWqinKdTRcW0GZiDjhvzBMRqW8=",
-			"dev": true,
 			"requires": {
 				"level-filesystem": "^1.0.1",
 				"level-js": "^2.1.3",
@@ -1963,20 +1943,17 @@
 		"buffer-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-			"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
-			"dev": true
+			"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
 		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-			"dev": true
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
 		},
 		"buffer-es6": {
 			"version": "4.9.3",
 			"resolved": "https://registry.npmjs.org/buffer-es6/-/buffer-es6-4.9.3.tgz",
-			"integrity": "sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ=",
-			"dev": true
+			"integrity": "sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ="
 		},
 		"buffer-from": {
 			"version": "1.1.0",
@@ -2006,8 +1983,7 @@
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-			"dev": true
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -2016,7 +1992,7 @@
 		},
 		"cacache": {
 			"version": "10.0.4",
-			"resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 			"requires": {
 				"bluebird": "^3.5.1",
@@ -2066,7 +2042,7 @@
 		},
 		"callsites": {
 			"version": "2.0.0",
-			"resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
 			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 		},
 		"camelcase": {
@@ -2079,7 +2055,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0",
 				"map-obj": "^2.0.0",
@@ -2089,8 +2064,7 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
 		},
@@ -2105,8 +2079,7 @@
 		"capture-stack-trace": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-			"dev": true
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -2136,8 +2109,7 @@
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-			"dev": true
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
 		},
 		"chokidar": {
 			"version": "1.7.0",
@@ -2272,26 +2244,22 @@
 		"clone": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-			"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-			"dev": true
+			"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
 		},
 		"clone-buffer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-			"dev": true
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
 		},
 		"clone-stats": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-			"dev": true
+			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
 		},
 		"cloneable-readable": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"process-nextick-args": "^2.0.0",
@@ -2302,7 +2270,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"mkdirp": "~0.5.0"
@@ -2344,7 +2311,6 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-			"dev": true,
 			"requires": {
 				"strip-ansi": "^3.0.0",
 				"wcwidth": "^1.0.0"
@@ -2353,14 +2319,12 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2378,8 +2342,7 @@
 		"command-join": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
-			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
-			"dev": true
+			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
 		},
 		"commander": {
 			"version": "2.16.0",
@@ -2395,7 +2358,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-			"dev": true,
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^3.0.0"
@@ -2445,9 +2407,9 @@
 			}
 		},
 		"connect-history-api-fallback": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
 		},
 		"console-browserify": {
 			"version": "1.1.0",
@@ -2460,8 +2422,7 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -2482,7 +2443,6 @@
 			"version": "1.1.24",
 			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
 			"integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-angular": "^1.6.6",
 				"conventional-changelog-atom": "^0.2.8",
@@ -2501,7 +2461,6 @@
 			"version": "1.6.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -2511,7 +2470,6 @@
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
 			"integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2520,7 +2478,6 @@
 			"version": "1.3.22",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz",
 			"integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
-			"dev": true,
 			"requires": {
 				"add-stream": "^1.0.0",
 				"conventional-changelog": "^1.1.24",
@@ -2533,7 +2490,6 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
 			"integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2542,7 +2498,6 @@
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
 			"integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-writer": "^3.0.9",
 				"conventional-commits-parser": "^2.1.7",
@@ -2563,7 +2518,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -2576,7 +2530,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -2585,7 +2538,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -2595,14 +2547,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -2613,7 +2563,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -2624,7 +2573,6 @@
 			"version": "0.3.12",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
 			"integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2633,7 +2581,6 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
 			"integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2642,7 +2589,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
 			"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2651,7 +2597,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -2660,7 +2605,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -2669,7 +2613,6 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
 			"integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -2678,14 +2621,12 @@
 		"conventional-changelog-preset-loader": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
-			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
-			"dev": true
+			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw=="
 		},
 		"conventional-changelog-writer": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
 			"integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^1.1.6",
@@ -2703,7 +2644,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
 			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
-			"dev": true,
 			"requires": {
 				"is-subset": "^0.1.1",
 				"modify-values": "^1.0.0"
@@ -2713,7 +2653,6 @@
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
-			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.0",
@@ -2728,7 +2667,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.4.10",
 				"conventional-commits-filter": "^1.1.1",
@@ -2742,14 +2680,12 @@
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^2.0.0",
 						"map-obj": "^1.0.0"
@@ -2759,7 +2695,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -2767,14 +2702,12 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				},
 				"meow": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^2.0.0",
 						"decamelize": "^1.1.2",
@@ -2791,14 +2724,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"redent": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
@@ -2808,7 +2739,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
 					"requires": {
 						"get-stdin": "^4.0.1"
 					}
@@ -2816,8 +2746,7 @@
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 				}
 			}
 		},
@@ -2855,9 +2784,9 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+			"integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -2895,7 +2824,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-			"dev": true,
 			"requires": {
 				"capture-stack-trace": "^1.0.0"
 			}
@@ -2990,7 +2918,7 @@
 		},
 		"d": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"requires": {
 				"es5-ext": "^0.10.9"
@@ -3000,7 +2928,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -3043,8 +2970,7 @@
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-			"dev": true
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -3070,7 +2996,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -3079,8 +3004,7 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				}
 			}
 		},
@@ -3092,8 +3016,7 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
 		},
 		"deep-equal": {
 			"version": "1.0.1",
@@ -3103,8 +3026,7 @@
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -3133,7 +3055,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			},
@@ -3141,8 +3062,7 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 				}
 			}
 		},
@@ -3150,7 +3070,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
 			"integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
-			"dev": true,
 			"requires": {
 				"abstract-leveldown": "~0.12.1"
 			}
@@ -3232,8 +3151,7 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -3262,8 +3180,13 @@
 		"detect-indent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-			"dev": true
+			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+		},
+		"detect-libc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+			"optional": true
 		},
 		"detect-newline": {
 			"version": "2.1.0",
@@ -3329,7 +3252,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
 			}
@@ -3342,8 +3264,7 @@
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"duplexify": {
 			"version": "3.6.0",
@@ -3369,7 +3290,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
 			"integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -3446,15 +3366,16 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
 			"requires": {
-				"es-to-primitive": "^1.1.1",
+				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
 			}
 		},
 		"es-to-primitive": {
@@ -3561,8 +3482,7 @@
 		"estree-walker": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
-			"integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
-			"dev": true
+			"integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig=="
 		},
 		"esutils": {
 			"version": "2.0.2",
@@ -3581,7 +3501,7 @@
 		},
 		"events": {
 			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
 			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"eventsource": {
@@ -3613,7 +3533,6 @@
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 			"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -3705,8 +3624,7 @@
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-			"dev": true
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -3731,7 +3649,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-			"dev": true,
 			"requires": {
 				"chardet": "^0.4.0",
 				"iconv-lite": "^0.4.17",
@@ -3805,7 +3722,7 @@
 			"dependencies": {
 				"core-js": {
 					"version": "1.2.7",
-					"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 				}
 			}
@@ -3846,7 +3763,7 @@
 		},
 		"finalhandler": {
 			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"requires": {
 				"debug": "2.6.9",
@@ -3891,9 +3808,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+			"integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
 			"requires": {
 				"debug": "=3.1.0"
 			},
@@ -3983,11 +3900,19 @@
 				"universalify": "^0.1.0"
 			}
 		},
+		"fs-minipass": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"optional": true,
+			"requires": {
+				"minipass": "^2.2.1"
+			}
+		},
 		"fs-mkdirp-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
 			"integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"through2": "^2.0.3"
@@ -4010,465 +3935,13 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.6.tgz",
+			"integrity": "sha512-BalK54tfK0pMC0jQFb2oHn1nz7JNQD/2ex5pBnCHgBi2xG7VV0cAOGy2RS2VbCqUXx5/6obMrMcQTJ8yjcGzbg==",
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
 				"node-pre-gyp": "^0.10.0"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"debug": {
-					"version": "2.6.9",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.5.1",
-					"bundled": true,
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"fs-minipass": {
-					"version": "1.2.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.21",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safer-buffer": "^2.1.0"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true
-				},
-				"minipass": {
-					"version": "2.2.4",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"needle": {
-					"version": "2.2.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.10.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.1.10",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.7",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"glob": "^7.0.5"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.1",
-					"bundled": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true,
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true,
-					"optional": true
-				},
-				"semver": {
-					"version": "5.5.0",
-					"bundled": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "4.4.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"string-width": "^1.0.2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"yallist": {
-					"version": "3.0.2",
-					"bundled": true
-				}
 			}
 		},
 		"function-bind": {
@@ -4480,7 +3953,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz",
 			"integrity": "sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "~1.0.26-4"
 			},
@@ -4488,14 +3960,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -4506,8 +3976,7 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -4515,7 +3984,6 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -4530,14 +3998,12 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4546,7 +4012,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4557,7 +4022,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4573,7 +4037,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"meow": "^3.3.0",
@@ -4585,14 +4048,12 @@
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^2.0.0",
 						"map-obj": "^1.0.0"
@@ -4602,7 +4063,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -4610,14 +4070,12 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				},
 				"meow": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^2.0.0",
 						"decamelize": "^1.1.2",
@@ -4634,14 +4092,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"redent": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
@@ -4651,7 +4107,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
 					"requires": {
 						"get-stdin": "^4.0.1"
 					}
@@ -4659,16 +4114,14 @@
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 				}
 			}
 		},
 		"get-port": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-			"dev": true
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
 		},
 		"get-stdin": {
 			"version": "4.0.1",
@@ -4697,7 +4150,6 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
-			"dev": true,
 			"requires": {
 				"dargs": "^4.0.1",
 				"lodash.template": "^4.0.2",
@@ -4710,7 +4162,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
 				"pify": "^2.3.0"
@@ -4719,8 +4170,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -4728,7 +4178,6 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
 			"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
-			"dev": true,
 			"requires": {
 				"meow": "^4.0.0",
 				"semver": "^5.5.0"
@@ -4738,7 +4187,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
 			}
@@ -4801,7 +4249,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
 			"integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-			"dev": true,
 			"requires": {
 				"extend": "^3.0.0",
 				"glob": "^7.1.1",
@@ -4856,7 +4303,6 @@
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-			"dev": true,
 			"requires": {
 				"create-error-class": "^3.0.0",
 				"duplexer3": "^0.1.4",
@@ -4883,7 +4329,7 @@
 		},
 		"handle-thing": {
 			"version": "1.2.5",
-			"resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
 			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
 		},
 		"handlebars": {
@@ -4947,8 +4393,7 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -5025,8 +4470,7 @@
 		"highlight.js": {
 			"version": "9.12.0",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
-			"dev": true
+			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -5083,7 +4527,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
 				"depd": "~1.1.2",
@@ -5109,7 +4553,7 @@
 		},
 		"http-proxy-middleware": {
 			"version": "0.18.0",
-			"resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
 			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
 			"requires": {
 				"http-proxy": "^1.16.2",
@@ -5402,8 +4846,7 @@
 		"idb-wrapper": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
-			"integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg==",
-			"dev": true
+			"integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
 		},
 		"ieee754": {
 			"version": "1.1.12",
@@ -5414,6 +4857,15 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
 			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+		},
+		"ignore-walk": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+			"optional": true,
+			"requires": {
+				"minimatch": "^3.0.4"
+			}
 		},
 		"import-local": {
 			"version": "1.0.0",
@@ -5432,8 +4884,7 @@
 		"indent-string": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-			"dev": true
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 		},
 		"indexof": {
 			"version": "0.0.1",
@@ -5457,14 +4908,12 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
@@ -5497,7 +4946,7 @@
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
-					"resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"requires": {
 						"camelcase": "^2.0.0",
@@ -5519,7 +4968,7 @@
 				},
 				"meow": {
 					"version": "3.7.0",
-					"resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"requires": {
 						"camelcase-keys": "^2.0.0",
@@ -5536,7 +4985,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"redent": {
@@ -5594,14 +5043,12 @@
 		"is": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
-			"integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI=",
-			"dev": true
+			"integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI="
 		},
 		"is-absolute": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
 			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-			"dev": true,
 			"requires": {
 				"is-relative": "^1.0.0",
 				"is-windows": "^1.0.1"
@@ -5736,14 +5183,12 @@
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-			"dev": true
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
 		},
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-			"dev": true
+			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
 		},
 		"is-number": {
 			"version": "2.1.0",
@@ -5756,14 +5201,12 @@
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-object": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz",
-			"integrity": "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc=",
-			"dev": true
+			"integrity": "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc="
 		},
 		"is-path-cwd": {
 			"version": "1.0.0",
@@ -5789,8 +5232,7 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -5825,8 +5267,7 @@
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-			"dev": true
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 		},
 		"is-regex": {
 			"version": "1.0.4",
@@ -5840,7 +5281,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
 			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-			"dev": true,
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
@@ -5848,8 +5288,7 @@
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-			"dev": true
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -5859,8 +5298,7 @@
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-			"dev": true
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
 		},
 		"is-symbol": {
 			"version": "1.0.2",
@@ -5874,7 +5312,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
 			}
@@ -5888,7 +5325,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
 			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-			"dev": true,
 			"requires": {
 				"unc-path-regex": "^0.1.2"
 			}
@@ -5901,8 +5337,7 @@
 		"is-valid-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-			"integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
-			"dev": true
+			"integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -5922,8 +5357,7 @@
 		"isbuffer": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz",
-			"integrity": "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s=",
-			"dev": true
+			"integrity": "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -6168,7 +5602,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -6369,7 +5803,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-5.1.0.tgz",
 			"integrity": "sha512-3EVf1puv2ox5wybQDfLX3AEn3IKOgDV4E76y4pO2hBu46DEtAFZZAm//X1pzPQpqKji0zqgMIzqzF/K+uGAX9A==",
-			"dev": true,
 			"requires": {
 				"jest-validate": "^23.0.1",
 				"mkdirp": "^0.5.1",
@@ -6484,9 +5917,9 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
-					"version": "0.5.9",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+					"version": "0.5.10",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+					"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -6559,7 +5992,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -6645,7 +6078,6 @@
 			"version": "23.4.0",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.4.0.tgz",
 			"integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"jest-get-type": "^22.1.0",
@@ -6677,9 +6109,9 @@
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -6725,7 +6157,7 @@
 		},
 		"jsesc": {
 			"version": "1.3.0",
-			"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 		},
 		"json-parse-better-errors": {
@@ -6747,7 +6179,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
 			"requires": {
 				"jsonify": "~0.0.0"
 			}
@@ -6764,7 +6195,7 @@
 		},
 		"json5": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
@@ -6783,14 +6214,12 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-			"dev": true
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 		},
 		"jsonwebtoken": {
 			"version": "8.2.1",
 			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
 			"integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
-			"dev": true,
 			"requires": {
 				"jws": "^3.1.4",
 				"lodash.includes": "^4.3.0",
@@ -6819,7 +6248,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
 			"integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
-			"dev": true,
 			"requires": {
 				"buffer-equal-constant-time": "1.0.1",
 				"ecdsa-sig-formatter": "1.0.10",
@@ -6830,7 +6258,6 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
 			"integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
-			"dev": true,
 			"requires": {
 				"jwa": "^1.1.5",
 				"safe-buffer": "^5.0.1"
@@ -6864,7 +6291,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
 			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.5"
 			}
@@ -6881,7 +6307,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lcov-result-merger/-/lcov-result-merger-3.1.0.tgz",
 			"integrity": "sha512-vGXaMNGZRr4cYvW+xMVg+rg7qd5DX9SbGXl+0S3k85+gRZVK4K7UvxPWzKb/qiMwe+4bx3EOrW2o4mbdb1WnsA==",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.3",
 				"vinyl": "^2.1.0",
@@ -6892,7 +6317,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
 			"integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
-			"dev": true,
 			"requires": {
 				"flush-write-stream": "^1.0.2"
 			}
@@ -6911,7 +6335,6 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.11.0.tgz",
 			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
-			"dev": true,
 			"requires": {
 				"async": "^1.5.0",
 				"chalk": "^2.1.0",
@@ -6958,7 +6381,6 @@
 					"version": "4.0.3",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^4.0.0",
@@ -6971,7 +6393,6 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/level-blobs/-/level-blobs-0.1.7.tgz",
 			"integrity": "sha1-mrm5e7mfHtv594o0M+Ie1WOGva8=",
-			"dev": true,
 			"requires": {
 				"level-peek": "1.0.6",
 				"once": "^1.3.0",
@@ -6981,14 +6402,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.1.14",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -6999,8 +6418,7 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -7008,7 +6426,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/level-filesystem/-/level-filesystem-1.2.0.tgz",
 			"integrity": "sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M=",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.4.4",
 				"errno": "^0.1.1",
@@ -7024,22 +6441,19 @@
 				"xtend": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
-					"integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=",
-					"dev": true
+					"integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
 				}
 			}
 		},
 		"level-fix-range": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/level-fix-range/-/level-fix-range-1.0.2.tgz",
-			"integrity": "sha1-vxW5Fa422EcMgh6IPd95zRZCCCg=",
-			"dev": true
+			"integrity": "sha1-vxW5Fa422EcMgh6IPd95zRZCCCg="
 		},
 		"level-hooks": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz",
 			"integrity": "sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM=",
-			"dev": true,
 			"requires": {
 				"string-range": "~1.2"
 			}
@@ -7048,7 +6462,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
 			"integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
-			"dev": true,
 			"requires": {
 				"abstract-leveldown": "~0.12.0",
 				"idb-wrapper": "^1.5.0",
@@ -7061,14 +6474,12 @@
 				"object-keys": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-					"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-					"dev": true
+					"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
 				},
 				"xtend": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
 					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-					"dev": true,
 					"requires": {
 						"object-keys": "~0.4.0"
 					}
@@ -7079,7 +6490,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz",
 			"integrity": "sha1-vsUccqgu5GTTNkNMfIdsP8vM538=",
-			"dev": true,
 			"requires": {
 				"level-fix-range": "~1.0.2"
 			}
@@ -7088,7 +6498,6 @@
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz",
 			"integrity": "sha1-dEwSxy0ucr543eO5tc2E1iGRQTo=",
-			"dev": true,
 			"requires": {
 				"level-fix-range": "2.0",
 				"level-hooks": ">=4.4.0 <5",
@@ -7099,14 +6508,12 @@
 				"clone": {
 					"version": "0.1.19",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
-					"integrity": "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU=",
-					"dev": true
+					"integrity": "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU="
 				},
 				"level-fix-range": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz",
 					"integrity": "sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug=",
-					"dev": true,
 					"requires": {
 						"clone": "~0.1.9"
 					}
@@ -7115,7 +6522,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
 					"integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
-					"dev": true,
 					"requires": {
 						"foreach": "~2.0.1",
 						"indexof": "~0.0.1",
@@ -7126,7 +6532,6 @@
 					"version": "2.0.6",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
 					"integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
-					"dev": true,
 					"requires": {
 						"is-object": "~0.1.2",
 						"object-keys": "~0.2.0"
@@ -7138,7 +6543,6 @@
 			"version": "0.18.6",
 			"resolved": "https://registry.npmjs.org/levelup/-/levelup-0.18.6.tgz",
 			"integrity": "sha1-5qAcsIlhbI7MApHCqb0/DETj5es=",
-			"dev": true,
 			"requires": {
 				"bl": "~0.8.1",
 				"deferred-leveldown": "~0.2.0",
@@ -7152,20 +6556,17 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"prr": {
 					"version": "0.0.0",
 					"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-					"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
-					"dev": true
+					"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -7176,20 +6577,17 @@
 				"semver": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
-					"integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI=",
-					"dev": true
+					"integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI="
 				},
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"xtend": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-					"integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-					"dev": true
+					"integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
 				}
 			}
 		},
@@ -7211,7 +6609,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^4.0.0",
@@ -7220,18 +6617,33 @@
 			}
 		},
 		"loader-runner": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
-			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+			"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
 		},
 		"loader-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+			"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
 			"requires": {
-				"big.js": "^3.1.3",
+				"big.js": "^5.2.2",
 				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"json5": "^1.0.1"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"locate-path": {
@@ -7251,8 +6663,7 @@
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
@@ -7262,44 +6673,37 @@
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
-			"dev": true
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
 		},
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
-			"dev": true
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
 		},
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
-			"dev": true
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
 		},
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
-			"dev": true
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-			"dev": true
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-			"dev": true
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
 		},
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-			"dev": true
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -7310,7 +6714,6 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0",
 				"lodash.templatesettings": "^4.0.0"
@@ -7320,7 +6723,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0"
 			}
@@ -7377,8 +6779,7 @@
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
 			"version": "4.1.3",
@@ -7392,14 +6793,12 @@
 		"ltgt": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-			"integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
-			"dev": true
+			"integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
 		},
 		"magic-string": {
 			"version": "0.22.5",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
 			"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
-			"dev": true,
 			"requires": {
 				"vlq": "^0.2.2"
 			}
@@ -7433,8 +6832,7 @@
 		"map-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-			"dev": true
+			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 		},
 		"map-visit": {
 			"version": "1.0.0",
@@ -7447,8 +6845,7 @@
 		"marked": {
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
-			"dev": true
+			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
 		},
 		"math-random": {
 			"version": "1.0.1",
@@ -7466,7 +6863,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
@@ -7490,7 +6887,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 			"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-			"dev": true,
 			"requires": {
 				"camelcase-keys": "^4.0.0",
 				"decamelize-keys": "^1.0.0",
@@ -7506,14 +6902,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"read-pkg-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -7638,10 +7032,34 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0"
+			}
+		},
+		"minipass": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+			"requires": {
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
+			},
+			"dependencies": {
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+				}
+			}
+		},
+		"minizlib": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+			"optional": true,
+			"requires": {
+				"minipass": "^2.2.1"
 			}
 		},
 		"mississippi": {
@@ -7691,14 +7109,12 @@
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-			"dev": true
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
 		},
 		"moment": {
 			"version": "2.22.2",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-			"dev": true
+			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
 		},
 		"move-concurrently": {
 			"version": "1.0.1",
@@ -7738,9 +7154,9 @@
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
 			"optional": true
 		},
 		"nanomatch": {
@@ -7783,6 +7199,17 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
+		"needle": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+			"integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+			"optional": true,
+			"requires": {
+				"debug": "^2.1.2",
+				"iconv-lite": "^0.4.4",
+				"sax": "^1.2.4"
+			}
+		},
 		"negotiator": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -7795,7 +7222,7 @@
 		},
 		"next-tick": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
 		"nice-try": {
@@ -7805,7 +7232,7 @@
 		},
 		"node-fetch": {
 			"version": "2.1.2",
-			"resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
 			"integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
 		},
 		"node-forge": {
@@ -7850,7 +7277,7 @@
 			"dependencies": {
 				"buffer": {
 					"version": "4.9.1",
-					"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 					"requires": {
 						"base64-js": "^1.0.2",
@@ -7876,6 +7303,34 @@
 				"which": "^1.3.0"
 			}
 		},
+		"node-pre-gyp": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+			"integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
+			"optional": true,
+			"requires": {
+				"detect-libc": "^1.0.2",
+				"mkdirp": "^0.5.1",
+				"needle": "^2.2.1",
+				"nopt": "^4.0.1",
+				"npm-packlist": "^1.1.6",
+				"npmlog": "^4.0.2",
+				"rc": "^1.2.7",
+				"rimraf": "^2.6.1",
+				"semver": "^5.3.0",
+				"tar": "^4"
+			}
+		},
+		"nopt": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+			"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+			"optional": true,
+			"requires": {
+				"abbrev": "1",
+				"osenv": "^0.1.4"
+			}
+		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -7899,7 +7354,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
 			"integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.2"
 			}
@@ -7908,7 +7362,6 @@
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/npm/-/npm-6.4.1.tgz",
 			"integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
-			"dev": true,
 			"requires": {
 				"JSONStream": "^1.3.4",
 				"abbrev": "~1.1.1",
@@ -8033,7 +7486,6 @@
 				"JSONStream": {
 					"version": "1.3.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"jsonparse": "^1.2.0",
 						"through": ">=2.2.7 <3"
@@ -8041,13 +7493,11 @@
 				},
 				"abbrev": {
 					"version": "1.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"agent-base": {
 					"version": "4.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"es6-promisify": "^5.0.0"
 					}
@@ -8055,7 +7505,6 @@
 				"agentkeepalive": {
 					"version": "3.4.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"humanize-ms": "^1.2.1"
 					}
@@ -8063,7 +7512,6 @@
 				"ajv": {
 					"version": "5.5.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
 						"fast-deep-equal": "^1.0.0",
@@ -8074,48 +7522,40 @@
 				"ansi-align": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0"
 					}
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
 				},
 				"ansicolors": {
 					"version": "0.3.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ansistyles": {
 					"version": "0.1.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"delegates": "^1.0.0",
 						"readable-stream": "^2.0.6"
@@ -8123,46 +7563,38 @@
 				},
 				"asap": {
 					"version": "2.0.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"asn1": {
 					"version": "0.2.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"safer-buffer": "~2.1.0"
 					}
 				},
 				"assert-plus": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"aws-sign2": {
 					"version": "0.7.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"aws4": {
 					"version": "1.8.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "^0.14.3"
@@ -8171,7 +7603,6 @@
 				"bin-links": {
 					"version": "1.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.0",
 						"cmd-shim": "^2.0.2",
@@ -8183,20 +7614,17 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"inherits": "~2.0.0"
 					}
 				},
 				"bluebird": {
 					"version": "3.5.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"boxen": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-align": "^2.0.0",
 						"camelcase": "^4.0.0",
@@ -8210,7 +7638,6 @@
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -8218,33 +7645,27 @@
 				},
 				"buffer-from": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"builtins": {
 					"version": "1.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"byline": {
 					"version": "5.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"byte-size": {
 					"version": "4.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cacache": {
 					"version": "11.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.1",
 						"chownr": "^1.0.1",
@@ -8264,28 +7685,23 @@
 				},
 				"call-limit": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"camelcase": {
 					"version": "4.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"capture-stack-trace": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"caseless": {
 					"version": "0.12.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"chalk": {
 					"version": "2.4.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8294,31 +7710,26 @@
 				},
 				"chownr": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ci-info": {
 					"version": "1.4.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cidr-regex": {
 					"version": "2.0.9",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ip-regex": "^2.1.0"
 					}
 				},
 				"cli-boxes": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cli-columns": {
 					"version": "3.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0",
 						"strip-ansi": "^3.0.1"
@@ -8327,7 +7738,6 @@
 				"cli-table3": {
 					"version": "0.5.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"colors": "^1.1.2",
 						"object-assign": "^4.1.0",
@@ -8337,7 +7747,6 @@
 				"cliui": {
 					"version": "4.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1",
 						"strip-ansi": "^4.0.0",
@@ -8346,13 +7755,11 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -8361,13 +7768,11 @@
 				},
 				"clone": {
 					"version": "1.0.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cmd-shim": {
 					"version": "2.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"mkdirp": "~0.5.0"
@@ -8375,37 +7780,31 @@
 				},
 				"co": {
 					"version": "4.6.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"color-convert": {
 					"version": "1.9.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"color-name": "^1.1.1"
 					}
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"colors": {
 					"version": "1.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"columnify": {
 					"version": "1.5.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"strip-ansi": "^3.0.0",
 						"wcwidth": "^1.0.0"
@@ -8414,20 +7813,17 @@
 				"combined-stream": {
 					"version": "1.0.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"delayed-stream": "~1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"concat-stream": {
 					"version": "1.6.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"inherits": "^2.0.3",
@@ -8438,7 +7834,6 @@
 				"config-chain": {
 					"version": "1.1.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ini": "^1.3.4",
 						"proto-list": "~1.2.1"
@@ -8447,7 +7842,6 @@
 				"configstore": {
 					"version": "3.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"dot-prop": "^4.1.0",
 						"graceful-fs": "^4.1.2",
@@ -8459,13 +7853,11 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"copy-concurrently": {
 					"version": "1.0.5",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1",
 						"fs-write-stream-atomic": "^1.0.8",
@@ -8477,20 +7869,17 @@
 					"dependencies": {
 						"iferr": {
 							"version": "0.1.5",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"create-error-class": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"capture-stack-trace": "^1.0.0"
 					}
@@ -8498,7 +7887,6 @@
 				"cross-spawn": {
 					"version": "5.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"shebang-command": "^1.2.0",
@@ -8507,18 +7895,15 @@
 				},
 				"crypto-random-string": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cyclist": {
 					"version": "0.2.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
 					}
@@ -8526,70 +7911,58 @@
 				"debug": {
 					"version": "3.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					},
 					"dependencies": {
 						"ms": {
 							"version": "2.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"debuglog": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"deep-extend": {
 					"version": "0.5.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"defaults": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"clone": "^1.0.2"
 					}
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"detect-indent": {
 					"version": "5.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"detect-newline": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"dezalgo": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"asap": "^2.0.0",
 						"wrappy": "1"
@@ -8598,25 +7971,21 @@
 				"dot-prop": {
 					"version": "4.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
 				},
 				"dotenv": {
 					"version": "5.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"duplexer3": {
 					"version": "0.1.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"duplexify": {
 					"version": "3.6.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.0.0",
 						"inherits": "^2.0.1",
@@ -8627,7 +7996,6 @@
 				"ecc-jsbn": {
 					"version": "0.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "~0.1.0",
@@ -8636,13 +8004,11 @@
 				},
 				"editor": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"encoding": {
 					"version": "0.1.12",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"iconv-lite": "~0.4.13"
 					}
@@ -8650,46 +8016,39 @@
 				"end-of-stream": {
 					"version": "1.4.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"once": "^1.4.0"
 					}
 				},
 				"err-code": {
 					"version": "1.1.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"errno": {
 					"version": "0.1.7",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"prr": "~1.0.1"
 					}
 				},
 				"es6-promise": {
 					"version": "4.2.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"es6-promisify": {
 					"version": "5.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"es6-promise": "^4.0.3"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -8702,38 +8061,31 @@
 				},
 				"extend": {
 					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"extsprintf": {
 					"version": "1.3.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"fast-deep-equal": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"fast-json-stable-stringify": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"figgy-pudding": {
 					"version": "3.4.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"find-npm-prefix": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -8741,7 +8093,6 @@
 				"flush-write-stream": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.4"
@@ -8749,13 +8100,11 @@
 				},
 				"forever-agent": {
 					"version": "0.6.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"form-data": {
 					"version": "2.3.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
 						"combined-stream": "1.0.6",
@@ -8765,7 +8114,6 @@
 				"from2": {
 					"version": "2.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.0"
@@ -8774,7 +8122,6 @@
 				"fs-minipass": {
 					"version": "1.2.5",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minipass": "^2.2.1"
 					}
@@ -8782,7 +8129,6 @@
 				"fs-vacuum": {
 					"version": "1.2.10",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"path-is-inside": "^1.0.1",
@@ -8792,7 +8138,6 @@
 				"fs-write-stream-atomic": {
 					"version": "1.0.10",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"iferr": "^0.1.5",
@@ -8802,20 +8147,17 @@
 					"dependencies": {
 						"iferr": {
 							"version": "0.1.5",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"inherits": "~2.0.0",
@@ -8826,7 +8168,6 @@
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"aproba": "^1.0.3",
 						"console-control-strings": "^1.0.0",
@@ -8841,7 +8182,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -8852,13 +8192,11 @@
 				},
 				"genfun": {
 					"version": "4.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"gentle-fs": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2",
 						"fs-vacuum": "^1.2.10",
@@ -8872,25 +8210,21 @@
 					"dependencies": {
 						"iferr": {
 							"version": "0.1.5",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
 					}
@@ -8898,7 +8232,6 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -8911,7 +8244,6 @@
 				"global-dirs": {
 					"version": "0.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ini": "^1.3.4"
 					}
@@ -8919,7 +8251,6 @@
 				"got": {
 					"version": "6.7.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"create-error-class": "^3.0.0",
 						"duplexer3": "^0.1.4",
@@ -8936,18 +8267,15 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"har-schema": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"har-validator": {
 					"version": "5.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ajv": "^5.3.0",
 						"har-schema": "^2.0.0"
@@ -8955,28 +8283,23 @@
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"hosted-git-info": {
 					"version": "2.7.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"http-cache-semantics": {
 					"version": "3.8.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"http-proxy-agent": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"agent-base": "4",
 						"debug": "3.1.0"
@@ -8985,7 +8308,6 @@
 				"http-signature": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0",
 						"jsprim": "^1.2.2",
@@ -8995,7 +8317,6 @@
 				"https-proxy-agent": {
 					"version": "2.2.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"agent-base": "^4.1.0",
 						"debug": "^3.1.0"
@@ -9004,7 +8325,6 @@
 				"humanize-ms": {
 					"version": "1.2.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ms": "^2.0.0"
 					}
@@ -9012,38 +8332,32 @@
 				"iconv-lite": {
 					"version": "0.4.23",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"iferr": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minimatch": "^3.0.4"
 					}
 				},
 				"import-lazy": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -9051,18 +8365,15 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"init-package-json": {
 					"version": "1.10.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
 						"npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -9076,23 +8387,19 @@
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ip": {
 					"version": "1.1.5",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ip-regex": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"builtin-modules": "^1.0.0"
 					}
@@ -9100,7 +8407,6 @@
 				"is-ci": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ci-info": "^1.0.0"
 					}
@@ -9108,7 +8414,6 @@
 				"is-cidr": {
 					"version": "2.0.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cidr-regex": "^2.0.8"
 					}
@@ -9116,7 +8421,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -9124,7 +8428,6 @@
 				"is-installed-globally": {
 					"version": "0.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"global-dirs": "^0.1.0",
 						"is-path-inside": "^1.0.0"
@@ -9132,92 +8435,75 @@
 				},
 				"is-npm": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-obj": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-path-inside": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"path-is-inside": "^1.0.1"
 					}
 				},
 				"is-redirect": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-retry-allowed": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isstream": {
 					"version": "0.1.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"json-parse-better-errors": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"json-schema-traverse": {
 					"version": "0.3.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"jsonparse": {
 					"version": "1.3.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"jsprim": {
 					"version": "1.4.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"assert-plus": "1.0.0",
 						"extsprintf": "1.3.0",
@@ -9228,20 +8514,17 @@
 				"latest-version": {
 					"version": "3.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"package-json": "^4.0.0"
 					}
 				},
 				"lazy-property": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
@@ -9249,7 +8532,6 @@
 				"libcipm": {
 					"version": "2.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"bin-links": "^1.1.2",
 						"bluebird": "^3.5.1",
@@ -9270,7 +8552,6 @@
 				"libnpmhook": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.1.0",
 						"npm-registry-fetch": "^3.0.0"
@@ -9279,7 +8560,6 @@
 						"npm-registry-fetch": {
 							"version": "3.1.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"bluebird": "^3.5.1",
 								"figgy-pudding": "^3.1.0",
@@ -9293,7 +8573,6 @@
 				"libnpx": {
 					"version": "10.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"dotenv": "^5.0.1",
 						"npm-package-arg": "^6.0.0",
@@ -9308,7 +8587,6 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -9317,7 +8595,6 @@
 				"lock-verify": {
 					"version": "2.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"npm-package-arg": "^5.1.2 || 6",
 						"semver": "^5.4.1"
@@ -9326,20 +8603,17 @@
 				"lockfile": {
 					"version": "1.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"signal-exit": "^3.0.2"
 					}
 				},
 				"lodash._baseindexof": {
 					"version": "3.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash._baseuniq": {
 					"version": "4.6.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"lodash._createset": "~4.0.0",
 						"lodash._root": "~3.0.0"
@@ -9347,71 +8621,58 @@
 				},
 				"lodash._bindcallback": {
 					"version": "3.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash._cacheindexof": {
 					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash._createcache": {
 					"version": "3.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"lodash._getnative": "^3.0.0"
 					}
 				},
 				"lodash._createset": {
 					"version": "4.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash._getnative": {
 					"version": "3.9.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash._root": {
 					"version": "3.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash.clonedeep": {
 					"version": "4.5.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash.restparam": {
 					"version": "3.6.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash.union": {
 					"version": "4.6.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash.uniq": {
 					"version": "4.5.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lodash.without": {
 					"version": "4.4.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lowercase-keys": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
@@ -9420,7 +8681,6 @@
 				"make-dir": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -9428,7 +8688,6 @@
 				"make-fetch-happen": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"agentkeepalive": "^3.4.1",
 						"cacache": "^11.0.1",
@@ -9445,52 +8704,44 @@
 				},
 				"meant": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
 				},
 				"mime-db": {
 					"version": "1.35.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"mime-types": {
 					"version": "2.1.19",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"mime-db": "~1.35.0"
 					}
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.3.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -9498,15 +8749,13 @@
 					"dependencies": {
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"minizlib": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minipass": "^2.2.1"
 					}
@@ -9514,7 +8763,6 @@
 				"mississippi": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"concat-stream": "^1.5.0",
 						"duplexify": "^3.4.2",
@@ -9531,7 +8779,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -9539,7 +8786,6 @@
 				"move-concurrently": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1",
 						"copy-concurrently": "^1.0.0",
@@ -9551,18 +8797,15 @@
 				},
 				"ms": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"mute-stream": {
 					"version": "0.0.7",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"node-fetch-npm": {
 					"version": "2.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"encoding": "^0.1.11",
 						"json-parse-better-errors": "^1.0.0",
@@ -9572,7 +8815,6 @@
 				"node-gyp": {
 					"version": "3.8.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"fstream": "^1.0.0",
 						"glob": "^7.0.3",
@@ -9591,20 +8833,17 @@
 						"nopt": {
 							"version": "3.0.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"abbrev": "1"
 							}
 						},
 						"semver": {
 							"version": "5.3.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"tar": {
 							"version": "2.2.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"block-stream": "*",
 								"fstream": "^1.0.2",
@@ -9616,7 +8855,6 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"abbrev": "1",
 						"osenv": "^0.1.4"
@@ -9625,7 +8863,6 @@
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
 						"is-builtin-module": "^1.0.0",
@@ -9636,7 +8873,6 @@
 				"npm-audit-report": {
 					"version": "1.3.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cli-table3": "^0.5.0",
 						"console-control-strings": "^1.1.0"
@@ -9644,18 +8880,15 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"npm-cache-filename": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"npm-install-checks": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"semver": "^2.3.0 || 3.x || 4 || 5"
 					}
@@ -9663,7 +8896,6 @@
 				"npm-lifecycle": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"byline": "^5.0.0",
 						"graceful-fs": "^4.1.11",
@@ -9677,13 +8909,11 @@
 				},
 				"npm-logical-tree": {
 					"version": "1.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"npm-package-arg": {
 					"version": "6.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.6.0",
 						"osenv": "^0.1.5",
@@ -9694,7 +8924,6 @@
 				"npm-packlist": {
 					"version": "1.1.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
 						"npm-bundled": "^1.0.1"
@@ -9703,7 +8932,6 @@
 				"npm-pick-manifest": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"npm-package-arg": "^6.0.0",
 						"semver": "^5.4.1"
@@ -9712,7 +8940,6 @@
 				"npm-profile": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2 || 2",
 						"make-fetch-happen": "^2.5.0 || 3 || 4"
@@ -9721,7 +8948,6 @@
 				"npm-registry-client": {
 					"version": "8.6.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"concat-stream": "^1.5.2",
 						"graceful-fs": "^4.1.6",
@@ -9739,13 +8965,11 @@
 					"dependencies": {
 						"retry": {
 							"version": "0.10.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"ssri": {
 							"version": "5.3.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.1"
 							}
@@ -9755,7 +8979,6 @@
 				"npm-registry-fetch": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.1",
 						"figgy-pudding": "^2.0.1",
@@ -9768,7 +8991,6 @@
 						"cacache": {
 							"version": "10.0.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"bluebird": "^3.5.1",
 								"chownr": "^1.0.1",
@@ -9788,7 +9010,6 @@
 								"mississippi": {
 									"version": "2.0.0",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"concat-stream": "^1.5.0",
 										"duplexify": "^3.4.2",
@@ -9806,13 +9027,11 @@
 						},
 						"figgy-pudding": {
 							"version": "2.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"make-fetch-happen": {
 							"version": "3.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"agentkeepalive": "^3.4.1",
 								"cacache": "^10.0.4",
@@ -9830,7 +9049,6 @@
 						"pump": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"end-of-stream": "^1.1.0",
 								"once": "^1.3.1"
@@ -9838,13 +9056,11 @@
 						},
 						"smart-buffer": {
 							"version": "1.1.15",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"socks": {
 							"version": "1.1.10",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ip": "^1.1.4",
 								"smart-buffer": "^1.0.13"
@@ -9853,7 +9069,6 @@
 						"socks-proxy-agent": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"agent-base": "^4.1.0",
 								"socks": "^1.1.10"
@@ -9862,7 +9077,6 @@
 						"ssri": {
 							"version": "5.3.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.1"
 							}
@@ -9872,20 +9086,17 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
 				},
 				"npm-user-validate": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"npmlog": {
 					"version": "4.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
 						"console-control-strings": "~1.1.0",
@@ -9895,41 +9106,34 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"oauth-sign": {
 					"version": "0.9.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
 				},
 				"opener": {
 					"version": "1.5.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -9938,13 +9142,11 @@
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
 						"os-tmpdir": "^1.0.0"
@@ -9952,13 +9154,11 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -9966,20 +9166,17 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"package-json": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"got": "^6.7.1",
 						"registry-auth-token": "^3.0.1",
@@ -9990,7 +9187,6 @@
 				"pacote": {
 					"version": "8.1.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.1",
 						"cacache": "^11.0.2",
@@ -10022,7 +9218,6 @@
 				"parallel-transform": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cyclist": "~0.2.2",
 						"inherits": "^2.0.3",
@@ -10031,53 +9226,43 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-is-inside": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"performance-now": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"pify": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"prepend-http": {
 					"version": "1.0.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"promise-inflight": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"promise-retry": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"err-code": "^1.0.0",
 						"retry": "^0.10.0"
@@ -10085,51 +9270,43 @@
 					"dependencies": {
 						"retry": {
 							"version": "0.10.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"promzard": {
 					"version": "0.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"read": "1"
 					}
 				},
 				"proto-list": {
 					"version": "1.2.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"protoduck": {
 					"version": "5.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"genfun": "^4.0.1"
 					}
 				},
 				"prr": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"psl": {
 					"version": "1.1.29",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"pump": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -10138,7 +9315,6 @@
 				"pumpify": {
 					"version": "1.5.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"duplexify": "^3.6.0",
 						"inherits": "^2.0.3",
@@ -10148,7 +9324,6 @@
 						"pump": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"end-of-stream": "^1.1.0",
 								"once": "^1.3.1"
@@ -10158,23 +9333,19 @@
 				},
 				"punycode": {
 					"version": "1.4.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"qrcode-terminal": {
 					"version": "0.12.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"qs": {
 					"version": "6.5.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"query-string": {
 					"version": "6.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"decode-uri-component": "^0.2.0",
 						"strict-uri-encode": "^2.0.0"
@@ -10182,13 +9353,11 @@
 				},
 				"qw": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"rc": {
 					"version": "1.2.7",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"deep-extend": "^0.5.1",
 						"ini": "~1.3.0",
@@ -10198,15 +9367,13 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"read": {
 					"version": "1.0.7",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"mute-stream": "~0.0.4"
 					}
@@ -10214,7 +9381,6 @@
 				"read-cmd-shim": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2"
 					}
@@ -10222,7 +9388,6 @@
 				"read-installed": {
 					"version": "4.0.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
 						"graceful-fs": "^4.1.2",
@@ -10236,7 +9401,6 @@
 				"read-package-json": {
 					"version": "2.0.13",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
 						"graceful-fs": "^4.1.2",
@@ -10248,7 +9412,6 @@
 				"read-package-tree": {
 					"version": "5.2.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
 						"dezalgo": "^1.0.0",
@@ -10260,7 +9423,6 @@
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -10274,7 +9436,6 @@
 				"readdir-scoped-modules": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
 						"dezalgo": "^1.0.0",
@@ -10285,7 +9446,6 @@
 				"registry-auth-token": {
 					"version": "3.3.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"rc": "^1.1.6",
 						"safe-buffer": "^5.0.1"
@@ -10294,7 +9454,6 @@
 				"registry-url": {
 					"version": "3.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"rc": "^1.0.1"
 					}
@@ -10302,7 +9461,6 @@
 				"request": {
 					"version": "2.88.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"aws-sign2": "~0.7.0",
 						"aws4": "^1.8.0",
@@ -10328,28 +9486,23 @@
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"resolve-from": {
 					"version": "4.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"retry": {
 					"version": "0.12.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
@@ -10357,43 +9510,36 @@
 				"run-queue": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"semver-diff": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"semver": "^5.0.3"
 					}
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"sha": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"readable-stream": "^2.0.2"
@@ -10402,40 +9548,33 @@
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"slash": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"smart-buffer": {
 					"version": "4.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"socks": {
 					"version": "2.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ip": "^1.1.5",
 						"smart-buffer": "^4.0.1"
@@ -10444,7 +9583,6 @@
 				"socks-proxy-agent": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"agent-base": "~4.2.0",
 						"socks": "~2.2.0"
@@ -10452,13 +9590,11 @@
 				},
 				"sorted-object": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"sorted-union-stream": {
 					"version": "2.1.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"from2": "^1.3.0",
 						"stream-iterate": "^1.1.0"
@@ -10467,7 +9603,6 @@
 						"from2": {
 							"version": "1.3.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"inherits": "~2.0.1",
 								"readable-stream": "~1.1.10"
@@ -10475,13 +9610,11 @@
 						},
 						"isarray": {
 							"version": "0.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"readable-stream": {
 							"version": "1.1.14",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
 								"inherits": "~2.0.1",
@@ -10491,15 +9624,13 @@
 						},
 						"string_decoder": {
 							"version": "0.10.31",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
 						"spdx-license-ids": "^3.0.0"
@@ -10507,13 +9638,11 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
 						"spdx-license-ids": "^3.0.0"
@@ -10521,13 +9650,11 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"sshpk": {
 					"version": "1.14.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"asn1": "~0.2.3",
 						"assert-plus": "^1.0.0",
@@ -10542,13 +9669,11 @@
 				},
 				"ssri": {
 					"version": "6.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"stream-each": {
 					"version": "1.2.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"stream-shift": "^1.0.0"
@@ -10557,7 +9682,6 @@
 				"stream-iterate": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"readable-stream": "^2.1.5",
 						"stream-shift": "^1.0.0"
@@ -10565,18 +9689,15 @@
 				},
 				"stream-shift": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"strict-uri-encode": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -10584,18 +9705,15 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -10605,38 +9723,32 @@
 				"string_decoder": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
 				},
 				"stringify-package": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -10644,7 +9756,6 @@
 				"tar": {
 					"version": "4.4.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"chownr": "^1.0.1",
 						"fs-minipass": "^1.2.5",
@@ -10657,33 +9768,28 @@
 					"dependencies": {
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"term-size": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"execa": "^0.7.0"
 					}
 				},
 				"text-table": {
 					"version": "0.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"through": {
 					"version": "2.3.8",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"through2": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"readable-stream": "^2.1.5",
 						"xtend": "~4.0.1"
@@ -10691,18 +9797,15 @@
 				},
 				"timed-out": {
 					"version": "4.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"tiny-relative-date": {
 					"version": "1.3.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"tough-cookie": {
 					"version": "2.4.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"psl": "^1.1.24",
 						"punycode": "^1.4.1"
@@ -10711,7 +9814,6 @@
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -10719,28 +9821,23 @@
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"typedarray": {
 					"version": "0.0.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"umask": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"unique-filename": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"unique-slug": "^2.0.0"
 					}
@@ -10748,7 +9845,6 @@
 				"unique-slug": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"imurmurhash": "^0.1.4"
 					}
@@ -10756,25 +9852,21 @@
 				"unique-string": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"crypto-random-string": "^1.0.0"
 					}
 				},
 				"unpipe": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"unzip-response": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"update-notifier": {
 					"version": "2.5.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"boxen": "^1.2.1",
 						"chalk": "^2.0.1",
@@ -10791,30 +9883,25 @@
 				"url-parse-lax": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"prepend-http": "^1.0.1"
 					}
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"util-extend": {
 					"version": "1.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"uuid": {
 					"version": "3.3.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
 						"spdx-expression-parse": "^3.0.0"
@@ -10823,7 +9910,6 @@
 				"validate-npm-package-name": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"builtins": "^1.0.3"
 					}
@@ -10831,7 +9917,6 @@
 				"verror": {
 					"version": "1.10.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0",
 						"core-util-is": "1.0.2",
@@ -10841,7 +9926,6 @@
 				"wcwidth": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"defaults": "^1.0.3"
 					}
@@ -10849,20 +9933,17 @@
 				"which": {
 					"version": "1.3.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.2"
 					},
@@ -10870,7 +9951,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -10882,7 +9962,6 @@
 				"widest-line": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1"
 					}
@@ -10890,7 +9969,6 @@
 				"worker-farm": {
 					"version": "1.6.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"errno": "~0.1.7"
 					}
@@ -10898,7 +9976,6 @@
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1"
@@ -10907,7 +9984,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -10918,13 +9994,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"write-file-atomic": {
 					"version": "2.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -10933,28 +10007,23 @@
 				},
 				"xdg-basedir": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"xtend": {
 					"version": "4.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"y18n": {
 					"version": "4.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"yargs": {
 					"version": "11.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -10972,19 +10041,33 @@
 					"dependencies": {
 						"y18n": {
 							"version": "3.2.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"yargs-parser": {
 					"version": "9.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
 				}
+			}
+		},
+		"npm-bundled": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+			"integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
+			"optional": true
+		},
+		"npm-packlist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
+			"integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
+			"optional": true,
+			"requires": {
+				"ignore-walk": "^3.0.1",
+				"npm-bundled": "^1.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -10999,7 +10082,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -11119,8 +10201,7 @@
 		"octal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/octal/-/octal-1.0.0.tgz",
-			"integrity": "sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws=",
-			"dev": true
+			"integrity": "sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws="
 		},
 		"on-finished": {
 			"version": "2.3.0",
@@ -11192,7 +10273,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
 			"integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.1"
 			}
@@ -11212,7 +10292,7 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
@@ -11245,6 +10325,16 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"osenv": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"optional": true,
+			"requires": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
+			}
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -11281,7 +10371,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-			"dev": true,
 			"requires": {
 				"got": "^6.7.1",
 				"registry-auth-token": "^3.0.1",
@@ -11290,9 +10379,9 @@
 			}
 		},
 		"pako": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.7.tgz",
-			"integrity": "sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ=="
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
+			"integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA=="
 		},
 		"parallel-transform": {
 			"version": "1.1.0",
@@ -11319,8 +10408,7 @@
 		"parse-github-repo-url": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-			"dev": true
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
@@ -11352,7 +10440,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-			"dev": true,
 			"requires": {
 				"error-ex": "^1.3.1",
 				"json-parse-better-errors": "^1.0.1"
@@ -11417,7 +10504,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
 			}
@@ -11471,9 +10557,9 @@
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
 		},
 		"portfinder": {
-			"version": "1.0.19",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
-			"integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+			"integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
 			"requires": {
 				"async": "^1.5.2",
 				"debug": "^2.2.0",
@@ -11493,8 +10579,7 @@
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 		},
 		"preserve": {
 			"version": "0.2.0",
@@ -11510,7 +10595,6 @@
 			"version": "23.2.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
 			"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0",
 				"ansi-styles": "^3.2.0"
@@ -11529,8 +10613,7 @@
 		"process-es6": {
 			"version": "0.11.6",
 			"resolved": "https://registry.npmjs.org/process-es6/-/process-es6-0.11.6.tgz",
-			"integrity": "sha1-xrs4n5qVH4K9TrFpYAEFvS/5x3g=",
-			"dev": true
+			"integrity": "sha1-xrs4n5qVH4K9TrFpYAEFvS/5x3g="
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
@@ -11540,8 +10623,7 @@
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-			"dev": true
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -11594,9 +10676,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
 		},
 		"public-encrypt": {
 			"version": "4.0.2",
@@ -11637,8 +10719,7 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
 		},
 		"qs": {
 			"version": "6.5.2",
@@ -11663,8 +10744,7 @@
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-			"dev": true
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		},
 		"randomatic": {
 			"version": "3.0.0",
@@ -11725,7 +10805,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -11736,8 +10815,7 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
@@ -11767,7 +10845,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2"
 			}
@@ -11776,7 +10853,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-			"dev": true,
 			"requires": {
 				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
@@ -12150,7 +11226,6 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"dev": true,
 			"requires": {
 				"resolve": "^1.1.6"
 			}
@@ -12159,7 +11234,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-			"dev": true,
 			"requires": {
 				"indent-string": "^3.0.0",
 				"strip-indent": "^2.0.0"
@@ -12216,7 +11290,6 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-			"dev": true,
 			"requires": {
 				"rc": "^1.1.6",
 				"safe-buffer": "^5.0.1"
@@ -12226,19 +11299,18 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-			"dev": true,
 			"requires": {
 				"rc": "^1.0.1"
 			}
 		},
 		"regjsgen": {
 			"version": "0.2.0",
-			"resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
 			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
 			"version": "0.1.5",
-			"resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -12246,7 +11318,7 @@
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
-					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
@@ -12255,7 +11327,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
 			"integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
-			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.5",
 				"is-utf8": "^0.2.1"
@@ -12265,7 +11336,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
 			"integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
-			"dev": true,
 			"requires": {
 				"remove-bom-buffer": "^3.0.0",
 				"safe-buffer": "^5.1.0",
@@ -12298,8 +11368,7 @@
 		"replace-ext": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-			"dev": true
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"request": {
 			"version": "2.88.0",
@@ -12412,7 +11481,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
 			"integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
-			"dev": true,
 			"requires": {
 				"value-or-function": "^3.0.0"
 			}
@@ -12466,7 +11534,6 @@
 			"version": "0.60.7",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.60.7.tgz",
 			"integrity": "sha512-Uj5I1A2PnDgA79P+v1dsNs1IHVydNgeJdKWRfoEJJdNMmyx07TRYqUtPUINaZ/gDusncFy1SZsT3lJnBBI8CGw==",
-			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
 				"@types/node": "*"
@@ -12476,7 +11543,6 @@
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.3.tgz",
 			"integrity": "sha512-g91ZZKZwTW7F7vL6jMee38I8coj/Q9GBdTmXXeFL7ldgC1Ky5WJvHgbKlAiXXTh762qvohhExwUgeQGFh9suGg==",
-			"dev": true,
 			"requires": {
 				"estree-walker": "^0.5.1",
 				"magic-string": "^0.22.4",
@@ -12488,7 +11554,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-3.0.0.tgz",
 			"integrity": "sha512-WUAV9/I/uFWvHhyRTqFb+3SIapjISFJS7R1xN/cXxWESrfYo9I8ncHI7AxJHflKRXhBVSv7revBVJh2wvhWh5w==",
-			"dev": true,
 			"requires": {
 				"rollup-pluginutils": "^2.2.0"
 			}
@@ -12497,7 +11562,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.1.2.tgz",
 			"integrity": "sha1-JKH+1KQyV7a2Q3HYq8bOGrFFl+k=",
-			"dev": true,
 			"requires": {
 				"browserify-fs": "^1.0.0",
 				"buffer-es6": "^4.9.2",
@@ -12509,7 +11573,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-globals/-/rollup-plugin-node-globals-1.2.1.tgz",
 			"integrity": "sha512-PZgkJkVLWZRdwx33GaAeD92UjmvCM7kM9i/8wgoe9hN901RrjVs8eVjg5DzQ+2kGZSiqyx0aiIunLnOOCWshWQ==",
-			"dev": true,
 			"requires": {
 				"acorn": "^5.5.0",
 				"buffer-es6": "^4.9.3",
@@ -12523,7 +11586,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz",
 			"integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "^2.0.0",
 				"is-module": "^1.0.0",
@@ -12533,8 +11595,7 @@
 				"builtin-modules": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
-					"integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
-					"dev": true
+					"integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg=="
 				}
 			}
 		},
@@ -12542,7 +11603,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz",
 			"integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
-			"dev": true,
 			"requires": {
 				"magic-string": "^0.22.4",
 				"minimatch": "^3.0.2",
@@ -12553,7 +11613,6 @@
 			"version": "0.15.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.15.1.tgz",
 			"integrity": "sha512-lJ/yfIj1fmp0KyfgPmd2QFeRpLgXlc58fS3Ha9Loc7/p3qByDL7CRndcI9MflE/pUSrfUdDjZMR0mHSKvqrZ+g==",
-			"dev": true,
 			"requires": {
 				"fs-extra": "^5.0.0",
 				"resolve": "^1.7.1",
@@ -12565,7 +11624,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
 					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^4.0.0",
@@ -12578,7 +11636,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-4.0.0.tgz",
 			"integrity": "sha512-f6W31EQLzxSEYfN3x6/lyljHqXSoCjXKcTsnwz3evQvHgU1+qTzU2SE0SIG7tbAvaCewp2UaZ5x3k6nYsxOP9A==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0-beta.47",
 				"uglify-js": "^3.3.25"
@@ -12587,14 +11644,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"uglify-js": {
 					"version": "3.4.4",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.4.tgz",
 					"integrity": "sha512-RiB1kNcC9RMyqwRrjXC+EjgLoXULoDnCaOnEDzUCHkBN0bHwmtF5rzDMiDWU29gu0kXCRRWwtcTAVFWRECmU2Q==",
-					"dev": true,
 					"requires": {
 						"commander": "~2.16.0",
 						"source-map": "~0.6.1"
@@ -12606,7 +11661,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.0.tgz",
 			"integrity": "sha512-xB6hsRsjdJdIYWEyYUJy/3ki5g69wrf0luHPGNK3ZSocV6HLNfio59l3dZ3TL4xUwEKgROhFi9jOCt6c5gfUWw==",
-			"dev": true,
 			"requires": {
 				"estree-walker": "^0.5.2",
 				"micromatch": "^2.3.11"
@@ -12636,14 +11690,12 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
 			"requires": {
 				"rx-lite": "*"
 			}
@@ -12663,7 +11715,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
 				"ret": "~0.1.10"
@@ -12940,7 +11992,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -13005,9 +12057,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
+			"integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw=="
 		},
 		"serve-index": {
 			"version": "1.9.1",
@@ -13107,7 +12159,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
 			"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -13279,7 +12330,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -13388,7 +12438,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
 			"requires": {
 				"through": "2"
 			}
@@ -13405,7 +12454,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.2"
 			}
@@ -13416,9 +12464,9 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+			"integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -13475,7 +12523,7 @@
 		},
 		"stream-browserify": {
 			"version": "2.0.1",
-			"resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"requires": {
 				"inherits": "~2.0.1",
@@ -13520,8 +12568,7 @@
 		"string-range": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz",
-			"integrity": "sha1-qJPtNH5yKZvIO++78qaSqNI51d0=",
-			"dev": true
+			"integrity": "sha1-qJPtNH5yKZvIO++78qaSqNI51d0="
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -13561,20 +12608,17 @@
 		"strip-indent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-			"dev": true
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"strong-log-transformer": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
-			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
 				"duplexer": "^0.1.1",
@@ -13586,8 +12630,7 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-					"dev": true
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
 				}
 			}
 		},
@@ -13601,7 +12644,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -13624,17 +12667,38 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
 			"integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
 		},
+		"tar": {
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+			"optional": true,
+			"requires": {
+				"chownr": "^1.1.1",
+				"fs-minipass": "^1.2.5",
+				"minipass": "^2.3.4",
+				"minizlib": "^1.1.1",
+				"mkdirp": "^0.5.0",
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.2"
+			},
+			"dependencies": {
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"optional": true
+				}
+			}
+		},
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-			"dev": true
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
 		},
 		"temp-write": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"is-stream": "^1.1.0",
@@ -13647,8 +12711,7 @@
 				"uuid": {
 					"version": "3.3.2",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-					"dev": true
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 				}
 			}
 		},
@@ -13656,7 +12719,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "^1.0.0",
 				"uuid": "^2.0.1"
@@ -13682,8 +12744,7 @@
 		"text-extensions": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
-			"dev": true
+			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg=="
 		},
 		"throat": {
 			"version": "4.1.0",
@@ -13708,7 +12769,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
 			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-			"dev": true,
 			"requires": {
 				"through2": "~2.0.0",
 				"xtend": "~4.0.0"
@@ -13722,8 +12782,7 @@
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
 			"version": "2.0.10",
@@ -13750,7 +12809,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
 			"integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
 				"is-negated-glob": "^1.0.0"
@@ -13808,7 +12866,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
 			"integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.3"
 			}
@@ -13833,14 +12890,12 @@
 		"trim-newlines": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-			"dev": true
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-			"dev": true
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
 		},
 		"trim-right": {
 			"version": "1.0.1",
@@ -13896,7 +12951,7 @@
 				},
 				"expect": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
 					"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
 					"requires": {
 						"ansi-styles": "^3.2.0",
@@ -13937,7 +12992,7 @@
 				},
 				"jest-diff": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
 					"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
 					"requires": {
 						"chalk": "^2.0.1",
@@ -13948,7 +13003,7 @@
 				},
 				"jest-environment-jsdom": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
 					"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
 					"requires": {
 						"jest-mock": "^22.4.3",
@@ -13958,7 +13013,7 @@
 				},
 				"jest-environment-node": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
 					"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
 					"requires": {
 						"jest-mock": "^22.4.3",
@@ -13985,7 +13040,7 @@
 				},
 				"jest-matcher-utils": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
 					"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
 					"requires": {
 						"chalk": "^2.0.1",
@@ -13995,7 +13050,7 @@
 				},
 				"jest-message-util": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
 					"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 					"requires": {
 						"@babel/code-frame": "^7.0.0-beta.35",
@@ -14007,17 +13062,17 @@
 				},
 				"jest-mock": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
 					"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q=="
 				},
 				"jest-regex-util": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
 					"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg=="
 				},
 				"jest-resolve": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
 					"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
 					"requires": {
 						"browser-resolve": "^1.11.2",
@@ -14026,7 +13081,7 @@
 				},
 				"jest-snapshot": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
 					"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
 					"requires": {
 						"chalk": "^2.0.1",
@@ -14039,7 +13094,7 @@
 				},
 				"jest-util": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
 					"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
 					"requires": {
 						"callsites": "^2.0.0",
@@ -14065,7 +13120,7 @@
 				},
 				"pretty-format": {
 					"version": "22.4.3",
-					"resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
 					"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
 					"requires": {
 						"ansi-regex": "^3.0.0",
@@ -14078,9 +13133,9 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
-					"version": "0.5.9",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+					"version": "0.5.10",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+					"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -14088,7 +13143,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -14119,7 +13174,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/ts-mockito/-/ts-mockito-2.3.0.tgz",
 			"integrity": "sha512-IB37YP8DppTHUf/aJeayUa7fZp7mn7HK+NYalzdyoy0z0vOpZwO+HiUKLUkK+c9ERcRlOdwm8Do99ndYsvm+Bw==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.5"
 			}
@@ -14130,9 +13184,9 @@
 			"integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw=="
 		},
 		"tslint": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+			"integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
 			"requires": {
 				"babel-code-frame": "^6.22.0",
 				"builtin-modules": "^1.1.1",
@@ -14204,14 +13258,12 @@
 		"typedarray-to-buffer": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
-			"integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw=",
-			"dev": true
+			"integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
 		},
 		"typedoc": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.11.1.tgz",
 			"integrity": "sha512-jdNIoHm5wkZqxQTe/g9AQ3LKnZyrzHXqu6A/c9GUOeJyBWLxNr7/Dm3rwFvLksuxRNwTvY/0HRDU9sJTa9WQSg==",
-			"dev": true,
 			"requires": {
 				"@types/fs-extra": "5.0.1",
 				"@types/handlebars": "4.0.36",
@@ -14236,7 +13288,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
 					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^4.0.0",
@@ -14246,22 +13297,19 @@
 				"typescript": {
 					"version": "2.7.2",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-					"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
-					"dev": true
+					"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
 				}
 			}
 		},
 		"typedoc-default-themes": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
-			"dev": true
+			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
 		},
 		"typescript": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
-			"dev": true
+			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
 		},
 		"ua-parser-js": {
 			"version": "0.7.19",
@@ -14344,8 +13392,7 @@
 		"unc-path-regex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-			"dev": true
+			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -14399,7 +13446,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-			"dev": true,
 			"requires": {
 				"json-stable-stringify": "^1.0.0",
 				"through2-filter": "^2.0.0"
@@ -14459,8 +13505,7 @@
 		"unzip-response": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-			"dev": true
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
 		},
 		"upath": {
 			"version": "1.1.0",
@@ -14514,7 +13559,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-			"dev": true,
 			"requires": {
 				"prepend-http": "^1.0.1"
 			}
@@ -14554,8 +13598,7 @@
 		"uuid": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-			"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-			"dev": true
+			"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.2",
@@ -14574,8 +13617,7 @@
 		"value-or-function": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
-			"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
-			"dev": true
+			"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
 		},
 		"vary": {
 			"version": "1.1.2",
@@ -14596,7 +13638,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
 			"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-			"dev": true,
 			"requires": {
 				"clone": "^2.1.1",
 				"clone-buffer": "^1.0.0",
@@ -14610,7 +13651,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
 			"integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-			"dev": true,
 			"requires": {
 				"fs-mkdirp-stream": "^1.0.0",
 				"glob-stream": "^6.1.0",
@@ -14635,7 +13675,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
 			"integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-			"dev": true,
 			"requires": {
 				"append-buffer": "^1.0.2",
 				"convert-source-map": "^1.5.0",
@@ -14649,8 +13688,7 @@
 		"vlq": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
-			"dev": true
+			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
 		},
 		"vm-browserify": {
 			"version": "0.0.4",
@@ -14687,7 +13725,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -14798,7 +13836,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}
@@ -15108,6 +14145,11 @@
 				"yargs": "^11.1.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -15126,6 +14168,21 @@
 						"string-width": "^2.1.1",
 						"strip-ansi": "^4.0.0",
 						"wrap-ansi": "^2.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
 					}
 				},
 				"cross-spawn": {
@@ -15159,9 +14216,9 @@
 					}
 				},
 				"inquirer": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+					"integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
@@ -15174,13 +14231,21 @@
 						"run-async": "^2.2.0",
 						"rxjs": "^6.1.0",
 						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
+						"strip-ansi": "^5.0.0",
 						"through": "^2.3.6"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+					"requires": {
+						"ansi-regex": "^4.0.0"
 					}
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -15390,7 +14455,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -15493,7 +14558,7 @@
 		},
 		"whatwg-fetch": {
 			"version": "2.0.4",
-			"resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
 			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"whatwg-mimetype": {
@@ -15528,7 +14593,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}
@@ -15613,7 +14677,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-			"dev": true,
 			"requires": {
 				"detect-indent": "^5.0.0",
 				"graceful-fs": "^4.1.2",
@@ -15627,7 +14690,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
 			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
-			"dev": true,
 			"requires": {
 				"sort-keys": "^2.0.0",
 				"write-json-file": "^2.2.0"
@@ -15644,8 +14706,7 @@
 		"xml": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-			"integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
-			"dev": true
+			"integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
@@ -15671,7 +14732,6 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
 			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0",
 				"cliui": "^3.2.0",
@@ -15691,20 +14751,17 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -15715,7 +14772,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -15728,7 +14784,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -15737,7 +14792,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -15749,7 +14803,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -15758,7 +14811,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
 					"requires": {
 						"pify": "^2.0.0"
 					}
@@ -15766,14 +14818,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"read-pkg": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^2.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -15784,7 +14834,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^2.0.0"
@@ -15794,7 +14843,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -15805,7 +14853,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"
 			},
@@ -15813,8 +14860,7 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
 		}

--- a/packages/browser/core/src/index.ts
+++ b/packages/browser/core/src/index.ts
@@ -17,6 +17,7 @@
 import {
   AnonymousAuthProvider,
   AnonymousCredential,
+  BSON,
   Codec,
   CustomAuthProvider,
   CustomCredential,
@@ -62,6 +63,7 @@ import NamedServiceClientFactory from "./services/internal/NamedServiceClientFac
 import StitchServiceClient from "./services/StitchServiceClient";
 
 export {
+  BSON,
   AnonymousAuthProvider,
   AnonymousCredential,
   CustomAuthProvider,

--- a/packages/browser/coretest/__tests__/auth/providers/userapikey/UserApiKeyAuthProviderClientIntTests.ts
+++ b/packages/browser/coretest/__tests__/auth/providers/userapikey/UserApiKeyAuthProviderClientIntTests.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import { App, AppResponse, Userpass } from "mongodb-stitch-core-admin-client";
-import { StitchServiceErrorCode, StitchServiceError } from "mongodb-stitch-core-sdk";
+import { BSON, StitchServiceErrorCode, StitchServiceError } from "mongodb-stitch-core-sdk";
 import { UserApiKeyAuthProviderClient, UserApiKeyCredential } from "mongodb-stitch-browser-core";
 import { BaseStitchBrowserIntTestHarness } from "mongodb-stitch-browser-testutils";
 

--- a/packages/browser/sdk/README.md
+++ b/packages/browser/sdk/README.md
@@ -187,13 +187,13 @@ And here is an example of importing BSON to generate an `ObjectId` using an HTML
    <body>
      <script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.2/stitch.js"></script>
      <script> 
-		function generateObjectId() {
-      const newObjectId = new stitch.BSON.ObjectId()
-		  document.getElementById('obj-id-display').innerHTML = 
-		    `Generated ObjectId: ${newObjectId}`;
-		}
-		 
-		window.onload = generateObjectId;
+      function generateObjectId() {
+        const newObjectId = new stitch.BSON.ObjectId()
+		    document.getElementById('obj-id-display').innerHTML = 
+		      `Generated ObjectId: ${newObjectId}`;
+		  }
+
+		  window.onload = generateObjectId;
      </script>
      <div id="obj-id-display">Generated ObjectId: None</div>
    </body>

--- a/packages/browser/sdk/README.md
+++ b/packages/browser/sdk/README.md
@@ -11,7 +11,7 @@ The official [MongoDB Stitch](https://stitch.mongodb.com/) Browser SDK for JavaS
 - [Example Usage](#example-usage)
 
 ## Documentation
-* [API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js/docs/4.1.0/index.html)
+* [API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js/docs/4.1.2/index.html)
 * [MongoDB Stitch Documentation](https://docs.mongodb.com/stitch/)
 
 ## Discussion
@@ -45,16 +45,16 @@ npm install mongodb-stitch-browser-services-twilio
 You can also include the SDK directly in your HTML code using script tags. For core SDK functionality and the remote MongoDB service, use the following:
 
 ```html
-<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.0/stitch.js"></script>
+<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.2/stitch.js"></script>
 ```
 
 For customized dependencies use the following:
 ```html
-<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.0/stitch-core.js"></script>
-<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.0/stitch-services-aws.js"></script>
-<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.0/stitch-services-http.js"></script>
-<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.0/stitch-services-mongodb-remote.js"></script>
-<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.0/stitch-services-twilio.js"></script>
+<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.2/stitch-core.js"></script>
+<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.2/stitch-services-aws.js"></script>
+<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.2/stitch-services-http.js"></script>
+<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.2/stitch-services-mongodb-remote.js"></script>
+<script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.2/stitch-services-twilio.js"></script>
 ```
 
 ## Example Usage
@@ -164,6 +164,41 @@ logged in anonymously as user 58c5d6ebb9ede022a3d75050
 #### Using BSON and Extended JSON
 
 This library depends on [js-bson](https://www.npmjs.com/package/js-bson).
+
+As a convenience, the SDK includes the `BSON` library, and you can import it as you would import other classes and values from the SDK.
+
+Here is an example of importing BSON to generate a BSON `ObjectID` using ES6:
+
+```javascript
+import { BSON } from 'mongodb-stitch-browser-sdk';
+
+let myObjectId = new BSON.ObjectId();
+console.log(`Generated ObjectId: ${myObjectId}`);
+```
+
+And here is an example of importing BSON to generate an `ObjectId` using an HTML `<script>` tag import:
+
+```html
+<!doctype html>
+  <html>
+   <head>
+     <title>MongoDB Stitch BSON Sample</title>
+   </head>
+   <body>
+     <script src="https://s3.amazonaws.com/stitch-sdks/js/bundles/4.1.2/stitch.js"></script>
+     <script> 
+		function generateObjectId() {
+      const newObjectId = new stitch.BSON.ObjectId()
+		  document.getElementById('obj-id-display').innerHTML = 
+		    `Generated ObjectId: ${newObjectId}`;
+		}
+		 
+		window.onload = generateObjectId;
+     </script>
+     <div id="obj-id-display">Generated ObjectId: None</div>
+   </body>
+  </html>
+```
 
 #### Executing a function
 1. Once logged in, executing a function happens via the `StitchAppClient`'s `callFunction()` method

--- a/packages/browser/services/aws-s3/__tests__/AwsS3ServiceClientIntTests.ts
+++ b/packages/browser/services/aws-s3/__tests__/AwsS3ServiceClientIntTests.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
-import { AnonymousCredential } from "mongodb-stitch-browser-core";
+import { AnonymousCredential, BSON } from "mongodb-stitch-browser-core";
 import { BaseStitchBrowserIntTestHarness } from "mongodb-stitch-browser-testutils";
 import {
   Anon,

--- a/packages/browser/services/aws/__tests__/AwsServiceClientIntTests.ts
+++ b/packages/browser/services/aws/__tests__/AwsServiceClientIntTests.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
-import { AnonymousCredential } from "mongodb-stitch-browser-core";
+import { AnonymousCredential, BSON } from "mongodb-stitch-browser-core";
 import { BaseStitchBrowserIntTestHarness } from "mongodb-stitch-browser-testutils";
 import {
   Anon,

--- a/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import { BaseStitchBrowserIntTestHarness } from "mongodb-stitch-browser-testutils";
 import {
   Anon,
@@ -27,6 +26,7 @@ import {
 } from "mongodb-stitch-core-admin-client";
 import {
   AnonymousCredential,
+  BSON,
   Codec,
   StitchServiceError,
   StitchServiceErrorCode

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import BSON from "bson";
 import AuthInfo from "./auth/internal/AuthInfo";
 import CoreStitchAuth from "./auth/internal/CoreStitchAuth";
 import CoreStitchUser from "./auth/internal/CoreStitchUser";
@@ -85,6 +86,7 @@ import StitchServiceError from "./StitchServiceError";
 import { StitchServiceErrorCode } from "./StitchServiceErrorCode";
 
 export {
+  BSON,
   AuthInfo,
   StitchAuthResponseCredential,
   AnonymousAuthProvider,

--- a/packages/core/testutils/src/BaseStitchIntTestHarness.ts
+++ b/packages/core/testutils/src/BaseStitchIntTestHarness.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import fetch from "cross-fetch";
 import {
   App,
@@ -29,6 +28,7 @@ import {
   StitchAdminClient
 } from "mongodb-stitch-core-admin-client";
 import {
+  BSON,
   UserApiKeyAuthProvider,
   UserPasswordCredential
 } from "mongodb-stitch-core-sdk";

--- a/packages/react-native/core/package-lock.json
+++ b/packages/react-native/core/package-lock.json
@@ -1,0 +1,5872 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"react-native": {
+			"version": "0.57.7",
+			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.57.7.tgz",
+			"integrity": "sha512-mdNibV6NblH8gbbcWjLjH6lVOkrXuCiIi+RQ+6e2QlrOIJVsKC216VvBhHsvdDIRO94v1qD8LMnTYlBY09qzQQ==",
+			"requires": {
+				"@babel/runtime": "^7.0.0",
+				"absolute-path": "^0.0.0",
+				"art": "^0.10.0",
+				"base64-js": "^1.1.2",
+				"chalk": "^1.1.1",
+				"commander": "^2.9.0",
+				"compression": "^1.7.1",
+				"connect": "^3.6.5",
+				"create-react-class": "^15.6.3",
+				"debug": "^2.2.0",
+				"denodeify": "^1.2.1",
+				"envinfo": "^5.7.0",
+				"errorhandler": "^1.5.0",
+				"escape-string-regexp": "^1.0.5",
+				"event-target-shim": "^1.0.5",
+				"fbjs": "^1.0.0",
+				"fbjs-scripts": "^1.0.0",
+				"fs-extra": "^1.0.0",
+				"glob": "^7.1.1",
+				"graceful-fs": "^4.1.3",
+				"inquirer": "^3.0.6",
+				"lodash": "^4.17.5",
+				"metro": "^0.48.1",
+				"metro-babel-register": "^0.48.1",
+				"metro-core": "^0.48.1",
+				"metro-memory-fs": "^0.48.1",
+				"mime": "^1.3.4",
+				"minimist": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"morgan": "^1.9.0",
+				"node-fetch": "^2.2.0",
+				"node-notifier": "^5.2.1",
+				"npmlog": "^2.0.4",
+				"opn": "^3.0.2",
+				"optimist": "^0.6.1",
+				"plist": "^3.0.0",
+				"pretty-format": "^4.2.1",
+				"promise": "^7.1.1",
+				"prop-types": "^15.5.8",
+				"react-clone-referenced-element": "^1.0.1",
+				"react-devtools-core": "^3.4.2",
+				"react-timer-mixin": "^0.13.2",
+				"regenerator-runtime": "^0.11.0",
+				"rimraf": "^2.5.4",
+				"semver": "^5.0.3",
+				"serve-static": "^1.13.1",
+				"shell-quote": "1.6.1",
+				"stacktrace-parser": "^0.1.3",
+				"ws": "^1.1.0",
+				"xcode": "^1.0.0",
+				"xmldoc": "^0.4.0",
+				"yargs": "^9.0.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/core": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.6.tgz",
+					"integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.1.6",
+						"@babel/helpers": "^7.1.5",
+						"@babel/parser": "^7.1.6",
+						"@babel/template": "^7.1.2",
+						"@babel/traverse": "^7.1.6",
+						"@babel/types": "^7.1.6",
+						"convert-source-map": "^1.1.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.10",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+							"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+						}
+					}
+				},
+				"@babel/generator": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+					"integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
+					"requires": {
+						"@babel/types": "^7.1.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.10",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+					"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-builder-binary-assignment-operator-visitor": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+					"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+					"requires": {
+						"@babel/helper-explode-assignable-expression": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-builder-react-jsx": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
+					"integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"esutils": "^2.0.0"
+					}
+				},
+				"@babel/helper-call-delegate": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
+					"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.0.0",
+						"@babel/traverse": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-define-map": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
+					"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+					"requires": {
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/types": "^7.0.0",
+						"lodash": "^4.17.10"
+					}
+				},
+				"@babel/helper-explode-assignable-expression": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+					"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+					"requires": {
+						"@babel/traverse": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+					"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+					"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+					"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
+					"integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-simple-access": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0",
+						"lodash": "^4.17.10"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+					"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+					"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+				},
+				"@babel/helper-regex": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+					"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+					"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.0.0",
+						"@babel/helper-wrap-function": "^7.1.0",
+						"@babel/template": "^7.1.0",
+						"@babel/traverse": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
+					"integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.0.0",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/traverse": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+					"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+					"requires": {
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+					"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
+					"integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
+					"requires": {
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/template": "^7.1.0",
+						"@babel/traverse": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.5.tgz",
+					"integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
+					"requires": {
+						"@babel/template": "^7.1.2",
+						"@babel/traverse": "^7.1.5",
+						"@babel/types": "^7.1.5"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"@babel/parser": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+					"integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ=="
+				},
+				"@babel/plugin-external-helpers": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0.tgz",
+					"integrity": "sha512-tZKTMdhZvTy0KCEX5EGQQm1RHr7jUa36q/yax1baEA0yZapVYmu10yW7LTqijITgSq416gPVjrcexiA6y4pJlA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-proposal-class-properties": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
+					"integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+					"requires": {
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-member-expression-to-functions": "^7.0.0",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.1.0",
+						"@babel/plugin-syntax-class-properties": "^7.0.0"
+					}
+				},
+				"@babel/plugin-proposal-export-default-from": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.0.0.tgz",
+					"integrity": "sha512-cWhkx6SyjZ4caFOanoPmDNgQCuYYTmou4QXy886JsyLTw/vhWQbop2gLKsWyyswrJkKTB7fSNxVYbP/oEsoySA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-export-default-from": "^7.0.0"
+					}
+				},
+				"@babel/plugin-proposal-nullish-coalescing-operator": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.0.0.tgz",
+					"integrity": "sha512-QIN3UFo1ul4ruAsjIqK43PeXedo1qY74zeGrODJl1KfCGeMc6qJC4rb5Ylml/smzxibqsDeVZGH+TmWHCldRQQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0"
+					}
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
+					"integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+					}
+				},
+				"@babel/plugin-proposal-optional-catch-binding": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
+					"integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
+					}
+				},
+				"@babel/plugin-proposal-optional-chaining": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.0.0.tgz",
+					"integrity": "sha512-7x8HLa71OzNiofbQUVakS0Kmg++6a+cXNfS7QKHbbv03SuSaumJyaWsfNgw+T7aqrJlqurYpZqrkPgXu0iZK0w==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-optional-chaining": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-class-properties": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
+					"integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-dynamic-import": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
+					"integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-export-default-from": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.0.0.tgz",
+					"integrity": "sha512-HNnjg/fFFbnuLAqr/Ocp1Y3GB4AjmXcu1xxn3ql3bS2kGrB/qi+Povshb8i3hOkE5jNozzh8r/0/lq1w8oOWbQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-flow": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0.tgz",
+					"integrity": "sha512-zGcuZWiWWDa5qTZ6iAnpG0fnX/GOu49pGR5PFvkQ9GmKNaSphXQnlNXh/LG20sqWtNrx/eB6krzfEzcwvUyeFA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-jsx": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz",
+					"integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-nullish-coalescing-operator": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.0.0.tgz",
+					"integrity": "sha512-oAJmMsAvTSIk9y0sZdU2S/nY44PEUuHN7EzNDMgbuR4e/OwyfR9lSmoBJBZ2lslFZIqhksrTt4i+av7uKfNYDw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-object-rest-spread": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
+					"integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-optional-catch-binding": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
+					"integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-optional-chaining": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.0.0.tgz",
+					"integrity": "sha512-QXedQsZf8yua1nNrXSePT0TsGSQH9A1iK08m9dhCMdZeJaaxYcQfXdgHWVV6Cp7WE/afPVvSKIsAHK5wP+yxDA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-typescript": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.1.5.tgz",
+					"integrity": "sha512-VqK5DFcS6/T8mT5CcJv1BwZLYFxkHiGZmP7Hs87F53lSToE/qfL7TpPrqFSaKyZi9w7Z/b/tmOGZZDupcJjFvw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-arrow-functions": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
+					"integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-async-to-generator": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
+					"integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-remap-async-to-generator": "^7.1.0"
+					}
+				},
+				"@babel/plugin-transform-block-scoped-functions": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
+					"integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-block-scoping": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.1.5.tgz",
+					"integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"lodash": "^4.17.10"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
+					"integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.0.0",
+						"@babel/helper-define-map": "^7.1.0",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.0.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-computed-properties": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
+					"integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
+					"integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-exponentiation-operator": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
+					"integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
+					"requires": {
+						"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-flow-strip-types": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.1.6.tgz",
+					"integrity": "sha512-0tyFAAjJmnRlr8MVJV39ASn1hv+PbdVP71hf7aAseqLfQ0o9QXk9htbMbq7/ZYXnUIp6gDw0lUUP0+PQMbbtmg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-flow": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
+					"integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-function-name": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
+					"integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
+					"requires": {
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-literals": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
+					"integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-member-expression-literals": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.0.0.tgz",
+					"integrity": "sha512-kgAGWcjVdflNPSaRb9rDPdGJ9/gF80VPmxx80gdKz6NSofHvxA2LofECQ+7GrDVzzH8zBJzTn1xlV4xnmWj/nw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
+					"integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
+					"requires": {
+						"@babel/helper-module-transforms": "^7.1.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-simple-access": "^7.1.0"
+					}
+				},
+				"@babel/plugin-transform-object-assign": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.0.0.tgz",
+					"integrity": "sha512-Dag8mxx7/03oj8F8PkNso8GEMhwGfeT0TL6KfMsa9Brjx4IpwZVl3WBvEmYks8BMhPmrvM5NQ/tjaMbwEj5ijA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-object-super": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
+					"integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.1.0"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
+					"integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
+					"requires": {
+						"@babel/helper-call-delegate": "^7.1.0",
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-property-literals": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.0.0.tgz",
+					"integrity": "sha512-7HK6/jB4MLpwQUJQ3diaX0pbCRcoL9asJscQfU3D1HpDwYdrH6yAUKleUNFHFyGNYBI9UeJrS2Jpx2JhtPKu5g==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-react-display-name": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
+					"integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-react-jsx": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.1.6.tgz",
+					"integrity": "sha512-iU/IUlPEYDRwuqLwqVobzPAZkBOQoZ9xRTBmj6ANuk5g/Egn/zdNGnXlSoKeNmKoYVeIRxx5GZhWmMhLik8dag==",
+					"requires": {
+						"@babel/helper-builder-react-jsx": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-jsx": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-react-jsx-source": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0.tgz",
+					"integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-jsx": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-regenerator": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+					"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+					"requires": {
+						"regenerator-transform": "^0.13.3"
+					}
+				},
+				"@babel/plugin-transform-runtime": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz",
+					"integrity": "sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"resolve": "^1.8.1",
+						"semver": "^5.5.1"
+					}
+				},
+				"@babel/plugin-transform-shorthand-properties": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
+					"integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-spread": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
+					"integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-sticky-regex": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
+					"integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-template-literals": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
+					"integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-typescript": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.1.0.tgz",
+					"integrity": "sha512-TOTtVeT+fekAesiCHnPz+PSkYSdOSLyLn42DI45nxg6iCdlQY6LIj/tYqpMB0y+YicoTUiYiXqF8rG6SKfhw6Q==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-typescript": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-unicode-regex": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
+					"integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.0.0",
+						"regexpu-core": "^4.1.3"
+					}
+				},
+				"@babel/register": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
+					"integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
+					"requires": {
+						"core-js": "^2.5.7",
+						"find-cache-dir": "^1.0.0",
+						"home-or-tmp": "^3.0.0",
+						"lodash": "^4.17.10",
+						"mkdirp": "^0.5.1",
+						"pirates": "^4.0.0",
+						"source-map-support": "^0.5.9"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "2.5.7",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+							"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+						}
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+					"integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+					"requires": {
+						"regenerator-runtime": "^0.12.0"
+					},
+					"dependencies": {
+						"regenerator-runtime": {
+							"version": "0.12.1",
+							"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+							"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+						}
+					}
+				},
+				"@babel/template": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+					"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.1.2",
+						"@babel/types": "^7.1.2"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+					"integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.1.6",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.0.0",
+						"@babel/parser": "^7.1.6",
+						"@babel/types": "^7.1.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.10"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+							"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+					"integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.10",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"absolute-path": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
+					"integrity": "sha1-p4di+9rftSl76ZsV01p4Wy8JW/c="
+				},
+				"accepts": {
+					"version": "1.3.5",
+					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+					"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+					"requires": {
+						"mime-types": "~2.1.18",
+						"negotiator": "0.6.1"
+					}
+				},
+				"ansi": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+					"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+				},
+				"ansi-colors": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+					"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+					"requires": {
+						"ansi-wrap": "^0.1.0"
+					}
+				},
+				"ansi-cyan": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+					"integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+					"requires": {
+						"ansi-wrap": "0.1.0"
+					}
+				},
+				"ansi-escapes": {
+					"version": "3.1.0",
+					"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+					"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+				},
+				"ansi-gray": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+					"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+					"requires": {
+						"ansi-wrap": "0.1.0"
+					}
+				},
+				"ansi-red": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+					"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+					"requires": {
+						"ansi-wrap": "0.1.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"ansi-wrap": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+					"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+				},
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+							"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+							"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+						},
+						"braces": {
+							"version": "2.3.2",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+							"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+							"requires": {
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						},
+						"expand-brackets": {
+							"version": "2.1.4",
+							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+							"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+							"requires": {
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "0.2.5",
+									"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+									"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+									"requires": {
+										"is-descriptor": "^0.1.0"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								},
+								"is-accessor-descriptor": {
+									"version": "0.1.6",
+									"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+									"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+									"requires": {
+										"kind-of": "^3.0.2"
+									},
+									"dependencies": {
+										"kind-of": {
+											"version": "3.2.2",
+											"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+											"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+											"requires": {
+												"is-buffer": "^1.1.5"
+											}
+										}
+									}
+								},
+								"is-data-descriptor": {
+									"version": "0.1.4",
+									"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+									"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+									"requires": {
+										"kind-of": "^3.0.2"
+									},
+									"dependencies": {
+										"kind-of": {
+											"version": "3.2.2",
+											"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+											"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+											"requires": {
+												"is-buffer": "^1.1.5"
+											}
+										}
+									}
+								},
+								"is-descriptor": {
+									"version": "0.1.6",
+									"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+									"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+									"requires": {
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
+									}
+								},
+								"kind-of": {
+									"version": "5.1.0",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+									"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+								}
+							}
+						},
+						"extend-shallow": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+							"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+							"requires": {
+								"assign-symbols": "^1.0.0",
+								"is-extendable": "^1.0.1"
+							},
+							"dependencies": {
+								"is-extendable": {
+									"version": "1.0.1",
+									"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+									"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+									"requires": {
+										"is-plain-object": "^2.0.4"
+									}
+								}
+							}
+						},
+						"extglob": {
+							"version": "2.0.4",
+							"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+							"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+							"requires": {
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+									"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+									"requires": {
+										"is-descriptor": "^1.0.0"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						},
+						"fill-range": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+							"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"is-number": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+						},
+						"micromatch": {
+							"version": "3.1.10",
+							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+							"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+							"requires": {
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
+							}
+						}
+					}
+				},
+				"are-we-there-yet": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
+					}
+				},
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"arr-diff": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+					"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+					"requires": {
+						"arr-flatten": "^1.0.1",
+						"array-slice": "^0.2.3"
+					}
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+					"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+				},
+				"arr-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+					"integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
+				},
+				"array-filter": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+					"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+				},
+				"array-map": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+					"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+				},
+				"array-reduce": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+					"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+				},
+				"array-slice": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+					"integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"art": {
+					"version": "0.10.3",
+					"resolved": "https://registry.npmjs.org/art/-/art-0.10.3.tgz",
+					"integrity": "sha512-HXwbdofRTiJT6qZX/FnchtldzJjS3vkLJxQilc3Xj+ma2MXjY4UAyQ0ls1XZYVnDvVIBiFZbC6QsvtW86TD6tQ=="
+				},
+				"asap": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+					"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"async-limiter": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+					"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+				},
+				"atob": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+					"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+				},
+				"babel-plugin-syntax-trailing-function-commas": {
+					"version": "7.0.0-beta.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+					"integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+				},
+				"babel-preset-fbjs": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.1.0.tgz",
+					"integrity": "sha512-j+B9xZsnqWFxHaqt3B8aFYftSgrcgbO5NF3mTtHYd6R442NJW2aBk3k+XvxXwIia98UuZxCg8psZY79bXbhwew==",
+					"requires": {
+						"@babel/plugin-proposal-class-properties": "^7.0.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+						"@babel/plugin-syntax-class-properties": "^7.0.0",
+						"@babel/plugin-syntax-flow": "^7.0.0",
+						"@babel/plugin-syntax-jsx": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+						"@babel/plugin-transform-arrow-functions": "^7.0.0",
+						"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+						"@babel/plugin-transform-block-scoping": "^7.0.0",
+						"@babel/plugin-transform-classes": "^7.0.0",
+						"@babel/plugin-transform-computed-properties": "^7.0.0",
+						"@babel/plugin-transform-destructuring": "^7.0.0",
+						"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+						"@babel/plugin-transform-for-of": "^7.0.0",
+						"@babel/plugin-transform-function-name": "^7.0.0",
+						"@babel/plugin-transform-literals": "^7.0.0",
+						"@babel/plugin-transform-member-expression-literals": "^7.0.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+						"@babel/plugin-transform-object-super": "^7.0.0",
+						"@babel/plugin-transform-parameters": "^7.0.0",
+						"@babel/plugin-transform-property-literals": "^7.0.0",
+						"@babel/plugin-transform-react-display-name": "^7.0.0",
+						"@babel/plugin-transform-react-jsx": "^7.0.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+						"@babel/plugin-transform-spread": "^7.0.0",
+						"@babel/plugin-transform-template-literals": "^7.0.0",
+						"babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+				},
+				"base": {
+					"version": "0.11.2",
+					"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+					"requires": {
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+						}
+					}
+				},
+				"base64-js": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+					"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+				},
+				"basic-auth": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+					"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+					"requires": {
+						"safe-buffer": "5.1.2"
+					}
+				},
+				"big-integer": {
+					"version": "1.6.36",
+					"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+					"integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
+				},
+				"bplist-creator": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+					"integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+					"requires": {
+						"stream-buffers": "~2.2.0"
+					}
+				},
+				"bplist-parser": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+					"integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+					"requires": {
+						"big-integer": "^1.6.7"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"bser": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+					"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+					"requires": {
+						"node-int64": "^0.4.0"
+					}
+				},
+				"buffer-crc32": {
+					"version": "0.2.13",
+					"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+					"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+				},
+				"buffer-from": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+					"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+				},
+				"bytes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+					"requires": {
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						}
+					}
+				},
+				"caller-callsite": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+					"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+					"requires": {
+						"callsites": "^2.0.0"
+					}
+				},
+				"caller-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+					"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+					"requires": {
+						"caller-callsite": "^2.0.0"
+					}
+				},
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"capture-exit": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+					"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+					"requires": {
+						"rsvp": "^3.3.3"
+					}
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"chardet": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+					"requires": {
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
+					},
+					"dependencies": {
+						"arr-union": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+							"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						}
+					}
+				},
+				"cli-cursor": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"requires": {
+						"restore-cursor": "^2.0.0"
+					}
+				},
+				"cli-width": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+					"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+					"requires": {
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"color-support": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+					"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+				},
+				"commander": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
+				"compressible": {
+					"version": "2.0.15",
+					"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+					"integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+					"requires": {
+						"mime-db": ">= 1.36.0 < 2"
+					}
+				},
+				"compression": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+					"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+					"requires": {
+						"accepts": "~1.3.5",
+						"bytes": "3.0.0",
+						"compressible": "~2.0.14",
+						"debug": "2.6.9",
+						"on-headers": "~1.0.1",
+						"safe-buffer": "5.1.2",
+						"vary": "~1.1.2"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+				},
+				"concat-stream": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
+					}
+				},
+				"connect": {
+					"version": "3.6.6",
+					"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+					"integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+					"requires": {
+						"debug": "2.6.9",
+						"finalhandler": "1.1.0",
+						"parseurl": "~1.3.2",
+						"utils-merge": "1.0.1"
+					}
+				},
+				"convert-source-map": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+					"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+					"requires": {
+						"safe-buffer": "~5.1.1"
+					}
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+					"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+				},
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+				},
+				"cosmiconfig": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
+					"integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
+					"requires": {
+						"import-fresh": "^2.0.0",
+						"is-directory": "^0.3.1",
+						"js-yaml": "^3.9.0",
+						"parse-json": "^4.0.0"
+					}
+				},
+				"create-react-class": {
+					"version": "15.6.3",
+					"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+					"integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+					"requires": {
+						"fbjs": "^0.8.9",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					},
+					"dependencies": {
+						"fbjs": {
+							"version": "0.8.17",
+							"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+							"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+							"requires": {
+								"core-js": "^1.0.0",
+								"isomorphic-fetch": "^2.1.1",
+								"loose-envify": "^1.0.0",
+								"object-assign": "^4.1.0",
+								"promise": "^7.1.1",
+								"setimmediate": "^1.0.5",
+								"ua-parser-js": "^0.7.18"
+							}
+						}
+					}
+				},
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+						}
+					}
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+				},
+				"denodeify": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+					"integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE="
+				},
+				"depd": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+					"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+				},
+				"destroy": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+					"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+				},
+				"detect-newline": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+					"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+				},
+				"dom-walk": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+					"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+				},
+				"ee-first": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+					"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+				},
+				"encodeurl": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+					"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"requires": {
+						"iconv-lite": "~0.4.13"
+					}
+				},
+				"end-of-stream": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+					"requires": {
+						"once": "^1.4.0"
+					}
+				},
+				"envinfo": {
+					"version": "5.12.1",
+					"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.12.1.tgz",
+					"integrity": "sha512-pwdo0/G3CIkQ0y6PCXq4RdkvId2elvtPCJMG0konqlrfkWQbf1DWeH9K2b/cvu2YgGvPPTOnonZxXM1gikFu1w=="
+				},
+				"error-ex": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+					"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"errorhandler": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.0.tgz",
+					"integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
+					"requires": {
+						"accepts": "~1.3.3",
+						"escape-html": "~1.0.3"
+					}
+				},
+				"escape-html": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+					"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+				},
+				"etag": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+					"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+				},
+				"event-target-shim": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.1.1.tgz",
+					"integrity": "sha1-qG5e5r2qFgVEddp5fM3fDFVphJE="
+				},
+				"eventemitter3": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+					"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+				},
+				"exec-sh": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+					"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+					"requires": {
+						"merge": "^1.2.0"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "6.0.5",
+							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+							"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+							"requires": {
+								"nice-try": "^1.0.4",
+								"path-key": "^2.0.1",
+								"semver": "^5.5.0",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+					"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+					"requires": {
+						"fill-range": "^2.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+					"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+					"requires": {
+						"kind-of": "^1.1.0"
+					}
+				},
+				"external-editor": {
+					"version": "2.2.0",
+					"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+					"requires": {
+						"chardet": "^0.4.0",
+						"iconv-lite": "^0.4.17",
+						"tmp": "^0.0.33"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"fancy-log": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+					"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+					"requires": {
+						"ansi-gray": "^0.1.1",
+						"color-support": "^1.1.3",
+						"time-stamp": "^1.0.0"
+					}
+				},
+				"fb-watchman": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+					"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+					"requires": {
+						"bser": "^2.0.0"
+					}
+				},
+				"fbjs": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+					"integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+					"requires": {
+						"core-js": "^2.4.1",
+						"fbjs-css-vars": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.18"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "2.5.7",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+							"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+						}
+					}
+				},
+				"fbjs-css-vars": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.1.tgz",
+					"integrity": "sha512-IM+v/C40MNZWqsLErc32e0TyIk/NhkkQZL0QmjBh6zi1eXv0/GeVKmKmueQX7nn9SXQBQbTUcB8zuexIF3/88w=="
+				},
+				"fbjs-scripts": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-1.0.1.tgz",
+					"integrity": "sha512-x8bfX7k0z5B24Ue0YqjZq/2QxxaKZUNbkGdX//zbQDElMJFqBRrvRi8O3qds7UNNzs78jYqIYCS32Sk/wu5UJg==",
+					"requires": {
+						"@babel/core": "^7.0.0",
+						"ansi-colors": "^1.0.1",
+						"babel-preset-fbjs": "^3.0.0",
+						"core-js": "^2.4.1",
+						"cross-spawn": "^5.1.0",
+						"fancy-log": "^1.3.2",
+						"object-assign": "^4.0.1",
+						"plugin-error": "^0.1.2",
+						"semver": "^5.1.0",
+						"through2": "^2.0.0"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "2.5.7",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+							"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+						}
+					}
+				},
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
+					}
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+					"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+				},
+				"fill-range": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+					"requires": {
+						"is-number": "^2.1.0",
+						"isobject": "^2.0.0",
+						"randomatic": "^3.0.0",
+						"repeat-element": "^1.1.2",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"finalhandler": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+					"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "~1.0.1",
+						"escape-html": "~1.0.3",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
+						"statuses": "~1.3.1",
+						"unpipe": "~1.0.0"
+					}
+				},
+				"find-cache-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+					"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^2.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+					"requires": {
+						"for-in": "^1.0.1"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+					"requires": {
+						"map-cache": "^0.2.2"
+					}
+				},
+				"fresh": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+					"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+				},
+				"fs-extra": {
+					"version": "1.0.0",
+					"resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+					"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0",
+						"klaw": "^1.0.0"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+				},
+				"fsevents": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+					"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+					"optional": true,
+					"requires": {
+						"nan": "^2.9.2",
+						"node-pre-gyp": "^0.10.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"deep-extend": {
+							"version": "0.5.1",
+							"bundled": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.21",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": "^2.1.0"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						},
+						"minipass": {
+							"version": "2.2.4",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.2.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"debug": "^2.1.2",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.10.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.0",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.1.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.1.10",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.7",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.5.1",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.0.5"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"bundled": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.5.0",
+							"bundled": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.0.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.2.4",
+								"minizlib": "^1.1.0",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"yallist": {
+							"version": "3.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"gauge": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+					"integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+					"requires": {
+						"ansi": "^0.3.0",
+						"has-unicode": "^2.0.0",
+						"lodash.pad": "^4.1.0",
+						"lodash.padend": "^4.1.0",
+						"lodash.padstart": "^4.1.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+					"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+					"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+					"requires": {
+						"glob-parent": "^2.0.0",
+						"is-glob": "^2.0.0"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
+				"global": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+					"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+					"requires": {
+						"min-document": "^2.19.0",
+						"process": "~0.5.1"
+					}
+				},
+				"globals": {
+					"version": "11.9.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+					"integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg=="
+				},
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+				},
+				"growly": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+					"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+					"requires": {
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						}
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+					"requires": {
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"home-or-tmp": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+					"integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
+				},
+				"hosted-git-info": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+					"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					},
+					"dependencies": {
+						"statuses": {
+							"version": "1.5.0",
+							"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+							"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+						}
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"image-size": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
+					"integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
+				},
+				"import-fresh": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+					"requires": {
+						"caller-path": "^2.0.0",
+						"resolve-from": "^3.0.0"
+					}
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"inquirer": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.0.4",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rx-lite": "^4.0.8",
+						"rx-lite-aggregates": "^4.0.8",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"invariant": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+					"requires": {
+						"loose-envify": "^1.0.0"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"is-directory": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+					"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+					"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+					"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+					"requires": {
+						"is-primitive": "^2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"requires": {
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						}
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+					"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+					"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+				},
+				"is-promise": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+					"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+					"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				},
+				"isomorphic-fetch": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+					"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+					"requires": {
+						"node-fetch": "^1.0.1",
+						"whatwg-fetch": ">=0.10.0"
+					},
+					"dependencies": {
+						"node-fetch": {
+							"version": "1.7.3",
+							"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+							"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+							"requires": {
+								"encoding": "^0.1.11",
+								"is-stream": "^1.0.1"
+							}
+						}
+					}
+				},
+				"jest-docblock": {
+					"version": "24.0.0-alpha.6",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.0.0-alpha.6.tgz",
+					"integrity": "sha512-veghPy2eBQ5r8XXd+VLK7AfCxJMTwqA8B2fknR24aibIkGW7dj4fq538HtwIvXkRpUO5f1b5x6IEsCb9g+e6qw==",
+					"requires": {
+						"detect-newline": "^2.1.0"
+					}
+				},
+				"jest-haste-map": {
+					"version": "24.0.0-alpha.2",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.0.0-alpha.2.tgz",
+					"integrity": "sha512-FTSIbJdmaddjgpcaXOq+sPGegcE28w7uOHonpsCuEwBQcB0REhkNYY9Wj/e1w+q3SBmEK1++ChgTMEXEzAf0yQ==",
+					"requires": {
+						"fb-watchman": "^2.0.0",
+						"graceful-fs": "^4.1.11",
+						"invariant": "^2.2.4",
+						"jest-docblock": "^24.0.0-alpha.2",
+						"jest-serializer": "^24.0.0-alpha.2",
+						"jest-worker": "^24.0.0-alpha.2",
+						"micromatch": "^2.3.11",
+						"sane": "^3.0.0"
+					}
+				},
+				"jest-serializer": {
+					"version": "24.0.0-alpha.6",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.0.0-alpha.6.tgz",
+					"integrity": "sha512-IPA5T6/GhlE6dedSk7Cd7YfuORnYjN0VD5iJVFn1Q81RJjpj++Hen5kJbKcg547vXsQ1TddV15qOA/zeIfOCLw=="
+				},
+				"jest-worker": {
+					"version": "24.0.0-alpha.2",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.0.0-alpha.2.tgz",
+					"integrity": "sha512-77YRl8eI4rrtdJ4mzzo4LVABecQmmy7lXsXc00rIJ9oiXJYbz4R4eL6RXcxZcRbwwqYjFL0g9h6H9iQaWqC/Kg==",
+					"requires": {
+						"merge-stream": "^1.0.1"
+					}
+				},
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+				},
+				"js-yaml": {
+					"version": "3.12.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+				},
+				"json-parse-better-errors": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+					"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+					"requires": {
+						"jsonify": "~0.0.0"
+					}
+				},
+				"json5": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+				},
+				"kind-of": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+					"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+				},
+				"klaw": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+					"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+					"requires": {
+						"graceful-fs": "^4.1.9"
+					}
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					},
+					"dependencies": {
+						"parse-json": {
+							"version": "2.2.0",
+							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+							"requires": {
+								"error-ex": "^1.2.0"
+							}
+						}
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				},
+				"lodash.pad": {
+					"version": "4.5.1",
+					"resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+					"integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA="
+				},
+				"lodash.padend": {
+					"version": "4.6.1",
+					"resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+					"integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+				},
+				"lodash.padstart": {
+					"version": "4.6.1",
+					"resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+					"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
+				},
+				"lodash.throttle": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+					"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+				},
+				"loose-envify": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+					"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+					"requires": {
+						"js-tokens": "^3.0.0 || ^4.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
+					"integrity": "sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^3.0.2"
+					}
+				},
+				"make-dir": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"requires": {
+						"pify": "^3.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+						}
+					}
+				},
+				"makeerror": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+					"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+					"requires": {
+						"tmpl": "1.0.x"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+					"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+					"requires": {
+						"object-visit": "^1.0.0"
+					}
+				},
+				"math-random": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+					"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+				},
+				"mem": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"merge": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+					"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+				},
+				"merge-stream": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+					"requires": {
+						"readable-stream": "^2.0.1"
+					}
+				},
+				"metro": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro/-/metro-0.48.3.tgz",
+					"integrity": "sha512-sf4Q95Zk7cvqi537WbQTvaPbPXflAk1zGWA50uchkF+frJHZWop5kwtbtWwvDGlPHgptjjXc3yTvIo5Y0LTkqQ==",
+					"requires": {
+						"@babel/core": "^7.0.0",
+						"@babel/generator": "^7.0.0",
+						"@babel/parser": "^7.0.0",
+						"@babel/plugin-external-helpers": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"@babel/traverse": "^7.0.0",
+						"@babel/types": "^7.0.0",
+						"absolute-path": "^0.0.0",
+						"async": "^2.4.0",
+						"babel-preset-fbjs": "^3.0.1",
+						"buffer-crc32": "^0.2.13",
+						"chalk": "^1.1.1",
+						"concat-stream": "^1.6.0",
+						"connect": "^3.6.5",
+						"debug": "^2.2.0",
+						"denodeify": "^1.2.1",
+						"eventemitter3": "^3.0.0",
+						"fbjs": "^1.0.0",
+						"fs-extra": "^1.0.0",
+						"graceful-fs": "^4.1.3",
+						"image-size": "^0.6.0",
+						"jest-haste-map": "24.0.0-alpha.2",
+						"jest-worker": "24.0.0-alpha.2",
+						"json-stable-stringify": "^1.0.1",
+						"lodash.throttle": "^4.1.1",
+						"merge-stream": "^1.0.1",
+						"metro-cache": "0.48.3",
+						"metro-config": "0.48.3",
+						"metro-core": "0.48.3",
+						"metro-minify-uglify": "0.48.3",
+						"metro-react-native-babel-preset": "0.48.3",
+						"metro-resolver": "0.48.3",
+						"metro-source-map": "0.48.3",
+						"mime-types": "2.1.11",
+						"mkdirp": "^0.5.1",
+						"node-fetch": "^2.2.0",
+						"nullthrows": "^1.1.0",
+						"react-transform-hmr": "^1.0.4",
+						"resolve": "^1.5.0",
+						"rimraf": "^2.5.4",
+						"serialize-error": "^2.1.0",
+						"source-map": "^0.5.6",
+						"temp": "0.8.3",
+						"throat": "^4.1.0",
+						"wordwrap": "^1.0.0",
+						"write-file-atomic": "^1.2.0",
+						"ws": "^1.1.0",
+						"xpipe": "^1.0.5",
+						"yargs": "^9.0.0"
+					},
+					"dependencies": {
+						"mime-db": {
+							"version": "1.23.0",
+							"resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+							"integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+						},
+						"mime-types": {
+							"version": "2.1.11",
+							"resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+							"integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+							"requires": {
+								"mime-db": "~1.23.0"
+							}
+						}
+					}
+				},
+				"metro-babel-register": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-babel-register/-/metro-babel-register-0.48.3.tgz",
+					"integrity": "sha512-KCuapWsM9Nrwb2XHQ0NhiTGZ9PrQfai8drhDrU5+A/aFGQ33N2wOvKet5OVRRyEuUvJ79Hbq0xs4UpFM13tQig==",
+					"requires": {
+						"@babel/core": "^7.0.0",
+						"@babel/plugin-proposal-class-properties": "^7.0.0",
+						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+						"@babel/plugin-proposal-optional-chaining": "^7.0.0",
+						"@babel/plugin-transform-async-to-generator": "^7.0.0",
+						"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+						"@babel/register": "^7.0.0",
+						"core-js": "^2.2.2",
+						"escape-string-regexp": "^1.0.5"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "2.5.7",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+							"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+						}
+					}
+				},
+				"metro-babel7-plugin-react-transform": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.48.3.tgz",
+					"integrity": "sha512-F3fjKig7KJl+5iqjWUStx/Sv3Oryw1cftIx0MhaXOgq4emdd1NYoC1sMYrGdDY8aLPDysH9J7sIeErH805oFUg==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0"
+					}
+				},
+				"metro-cache": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.48.3.tgz",
+					"integrity": "sha512-q49ult2PW2BYTuGCS5RXmMB+ejdOWtNHWh9yZS5XvI/xlfLZjJL47yakcOz3C8UImdRhWV8X890/+rQU7nALCg==",
+					"requires": {
+						"jest-serializer": "24.0.0-alpha.2",
+						"metro-core": "0.48.3",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4"
+					},
+					"dependencies": {
+						"jest-serializer": {
+							"version": "24.0.0-alpha.2",
+							"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.0.0-alpha.2.tgz",
+							"integrity": "sha512-jLHHT71gyYdgMH5sFWP/e8bZjq/TC5iz9DQZlLsRE/7Er//m8WqyiNJs022FEc18PLq3jyk/z06N0xS6YlbsUA=="
+						}
+					}
+				},
+				"metro-config": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.48.3.tgz",
+					"integrity": "sha512-rpO0Edy6H7N2RnEUPQufIG6DdU/lXZcMIRP3UHR93Q7IuZEwkSd3lS0trCMqdkj5Hx7eIx+gj/MQrNDSa0L0gw==",
+					"requires": {
+						"cosmiconfig": "^5.0.5",
+						"metro": "0.48.3",
+						"metro-cache": "0.48.3",
+						"metro-core": "0.48.3",
+						"pretty-format": "^23.4.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"pretty-format": {
+							"version": "23.6.0",
+							"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+							"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+							"requires": {
+								"ansi-regex": "^3.0.0",
+								"ansi-styles": "^3.2.0"
+							}
+						}
+					}
+				},
+				"metro-core": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.48.3.tgz",
+					"integrity": "sha512-bLIikpGBvdaZhwvmnpY5OwS2XhOWGX7YUvRN4IegfTOYo88TzL/SAB5Osr7lpYGvTmGdJFJ5Mqr3Xy4bVGFEvA==",
+					"requires": {
+						"jest-haste-map": "24.0.0-alpha.2",
+						"lodash.throttle": "^4.1.1",
+						"metro-resolver": "0.48.3",
+						"wordwrap": "^1.0.0"
+					}
+				},
+				"metro-memory-fs": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-memory-fs/-/metro-memory-fs-0.48.3.tgz",
+					"integrity": "sha512-Ku6k0JHZZ/EIHlIJZZEAJ7ItDq/AdIOpmgt4ebkQ6WJRUOc0960K3BQdRFiwL8riQKWJMlKZcXc4/2ktoY3U9A=="
+				},
+				"metro-minify-uglify": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.48.3.tgz",
+					"integrity": "sha512-EvzoqPMbm839T6AXSYWF76b/VNqoY3E1oAbZoyZbN/J7EHHgz2xEVt4M49fI6tEKPCPzpEpGnJKoxjnkV9XdrA==",
+					"requires": {
+						"uglify-es": "^3.1.9"
+					}
+				},
+				"metro-react-native-babel-preset": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.48.3.tgz",
+					"integrity": "sha512-GDW4yWk8z5RGk8A67OTS05luxCHZFDHbEuzesyxG1SlE/W6ODfJOPQpIFlFuPUEvVDunG0lYn3dGBL2VcaVVpQ==",
+					"requires": {
+						"@babel/plugin-proposal-class-properties": "^7.0.0",
+						"@babel/plugin-proposal-export-default-from": "^7.0.0",
+						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+						"@babel/plugin-proposal-optional-chaining": "^7.0.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.0.0",
+						"@babel/plugin-syntax-export-default-from": "^7.0.0",
+						"@babel/plugin-transform-arrow-functions": "^7.0.0",
+						"@babel/plugin-transform-block-scoping": "^7.0.0",
+						"@babel/plugin-transform-classes": "^7.0.0",
+						"@babel/plugin-transform-computed-properties": "^7.0.0",
+						"@babel/plugin-transform-destructuring": "^7.0.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+						"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+						"@babel/plugin-transform-for-of": "^7.0.0",
+						"@babel/plugin-transform-function-name": "^7.0.0",
+						"@babel/plugin-transform-literals": "^7.0.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+						"@babel/plugin-transform-object-assign": "^7.0.0",
+						"@babel/plugin-transform-parameters": "^7.0.0",
+						"@babel/plugin-transform-react-display-name": "^7.0.0",
+						"@babel/plugin-transform-react-jsx": "^7.0.0",
+						"@babel/plugin-transform-react-jsx-source": "^7.0.0",
+						"@babel/plugin-transform-regenerator": "^7.0.0",
+						"@babel/plugin-transform-runtime": "^7.0.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+						"@babel/plugin-transform-spread": "^7.0.0",
+						"@babel/plugin-transform-sticky-regex": "^7.0.0",
+						"@babel/plugin-transform-template-literals": "^7.0.0",
+						"@babel/plugin-transform-typescript": "^7.0.0",
+						"@babel/plugin-transform-unicode-regex": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"metro-babel7-plugin-react-transform": "0.48.3",
+						"react-transform-hmr": "^1.0.4"
+					}
+				},
+				"metro-resolver": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.48.3.tgz",
+					"integrity": "sha512-aXZdd4SWVPnTlnJ55f918QLvGOE8zlrGt8y8/BS0EktzPORkkXnouzC0dtkq5lTpFSX7b1OD2z3ZtZLxM5sQVg==",
+					"requires": {
+						"absolute-path": "^0.0.0"
+					}
+				},
+				"metro-source-map": {
+					"version": "0.48.3",
+					"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.48.3.tgz",
+					"integrity": "sha512-TAIn1c/G69PHa+p4CUl7myXw5gOT4J1xXXLKAjIOA6xjxttMEa1S5co6fsXzvTMR+psK9OAsgBW3VAaEcJGEcw==",
+					"requires": {
+						"source-map": "^0.5.6"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+							"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+							"requires": {
+								"arr-flatten": "^1.0.1"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+				},
+				"mime-db": {
+					"version": "1.37.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+					"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+				},
+				"mime-types": {
+					"version": "2.1.21",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+					"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+					"requires": {
+						"mime-db": "~1.37.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+				},
+				"min-document": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+					"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+					"requires": {
+						"dom-walk": "^0.1.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+					"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+					"requires": {
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"requires": {
+						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+						}
+					}
+				},
+				"morgan": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+					"integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+					"requires": {
+						"basic-auth": "~2.0.0",
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"on-finished": "~2.3.0",
+						"on-headers": "~1.0.1"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"mute-stream": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+				},
+				"nan": {
+					"version": "2.11.1",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+					"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+					"optional": true
+				},
+				"nanomatch": {
+					"version": "1.2.13",
+					"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+					"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+							"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+							"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+						},
+						"extend-shallow": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+							"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+							"requires": {
+								"assign-symbols": "^1.0.0",
+								"is-extendable": "^1.0.1"
+							}
+						},
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+						}
+					}
+				},
+				"negotiator": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+					"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+				},
+				"nice-try": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+					"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+				},
+				"node-fetch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+					"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+				},
+				"node-int64": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+					"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+				},
+				"node-modules-regexp": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+					"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+				},
+				"node-notifier": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
+					"integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
+					"requires": {
+						"growly": "^1.3.0",
+						"semver": "^5.5.0",
+						"shellwords": "^0.1.1",
+						"which": "^1.3.0"
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"npmlog": {
+					"version": "2.0.4",
+					"resolved": "http://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+					"integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+					"requires": {
+						"ansi": "~0.3.1",
+						"are-we-there-yet": "~1.1.2",
+						"gauge": "~1.2.5"
+					}
+				},
+				"nullthrows": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.0.tgz",
+					"integrity": "sha512-YoigDq49JRqVCUlb4XlwZirXQiNCoXdwoyfklXJAEYHN+XKHWgDkrcWxNgxEtP7N+XF9Akp7Lr6wLq8HZxLttw=="
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+					"requires": {
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+					"requires": {
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						}
+					}
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+					"requires": {
+						"for-own": "^0.1.4",
+						"is-extendable": "^0.1.1"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+					"requires": {
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						}
+					}
+				},
+				"on-finished": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+					"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+					"requires": {
+						"ee-first": "1.1.1"
+					}
+				},
+				"on-headers": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+					"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"opn": {
+					"version": "3.0.3",
+					"resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+					"integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
+					"requires": {
+						"object-assign": "^4.0.1"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.10",
+							"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+							"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+						},
+						"wordwrap": {
+							"version": "0.0.3",
+							"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+							"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+						}
+					}
+				},
+				"options": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+					"integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					},
+					"dependencies": {
+						"execa": {
+							"version": "0.7.0",
+							"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+							"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+							"requires": {
+								"cross-spawn": "^5.0.1",
+								"get-stream": "^3.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
+							}
+						},
+						"get-stream": {
+							"version": "3.0.0",
+							"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+						}
+					}
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+					"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+					"requires": {
+						"glob-base": "^0.3.0",
+						"is-dotfile": "^1.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"parseurl": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+					"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+					"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"pegjs": {
+					"version": "0.10.0",
+					"resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+					"integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				},
+				"pirates": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
+					"integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+					"requires": {
+						"node-modules-regexp": "^1.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				},
+				"plist": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+					"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+					"requires": {
+						"base64-js": "^1.2.3",
+						"xmlbuilder": "^9.0.7",
+						"xmldom": "0.1.x"
+					}
+				},
+				"plugin-error": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+					"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+					"requires": {
+						"ansi-cyan": "^0.1.1",
+						"ansi-red": "^0.1.1",
+						"arr-diff": "^1.0.1",
+						"arr-union": "^2.0.1",
+						"extend-shallow": "^1.1.2"
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+					"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+					"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+				},
+				"pretty-format": {
+					"version": "4.3.1",
+					"resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
+					"integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
+				},
+				"private": {
+					"version": "0.1.8",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+					"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+				},
+				"process": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "~2.0.3"
+					}
+				},
+				"prop-types": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+					"requires": {
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"randomatic": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+					"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+					"requires": {
+						"is-number": "^4.0.0",
+						"kind-of": "^6.0.0",
+						"math-random": "^1.0.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+						}
+					}
+				},
+				"range-parser": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+					"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+				},
+				"react-clone-referenced-element": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz",
+					"integrity": "sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg=="
+				},
+				"react-deep-force-update": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz",
+					"integrity": "sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA=="
+				},
+				"react-devtools-core": {
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.4.3.tgz",
+					"integrity": "sha512-t3f6cRH5YSKv8qjRl1Z+1e0OwBZwJSdOAhJ9QAJdVKML7SmqAKKv3DxF+Ue03pE1N2UipPsLmaNcPzzMjIdZQg==",
+					"requires": {
+						"shell-quote": "^1.6.1",
+						"ws": "^3.3.1"
+					},
+					"dependencies": {
+						"ultron": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+							"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+						},
+						"ws": {
+							"version": "3.3.3",
+							"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+							"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+							"requires": {
+								"async-limiter": "~1.0.0",
+								"safe-buffer": "~5.1.0",
+								"ultron": "~1.1.0"
+							}
+						}
+					}
+				},
+				"react-proxy": {
+					"version": "1.1.8",
+					"resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
+					"integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
+					"requires": {
+						"lodash": "^4.6.1",
+						"react-deep-force-update": "^1.0.0"
+					}
+				},
+				"react-timer-mixin": {
+					"version": "0.13.4",
+					"resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz",
+					"integrity": "sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q=="
+				},
+				"react-transform-hmr": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
+					"integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
+					"requires": {
+						"global": "^4.3.0",
+						"react-proxy": "^1.1.7"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"regenerate": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+					"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+				},
+				"regenerate-unicode-properties": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+					"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+					"requires": {
+						"regenerate": "^1.4.0"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				},
+				"regenerator-transform": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+					"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+					"requires": {
+						"private": "^0.1.6"
+					}
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+					"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+					"requires": {
+						"is-equal-shallow": "^0.1.3"
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+					"requires": {
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+							"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+							"requires": {
+								"assign-symbols": "^1.0.0",
+								"is-extendable": "^1.0.1"
+							}
+						},
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"regexpu-core": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+					"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^7.0.0",
+						"regjsgen": "^0.4.0",
+						"regjsparser": "^0.3.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.0.2"
+					}
+				},
+				"regjsgen": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
+				},
+				"regjsparser": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+					"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+					"requires": {
+						"jsesc": "~0.5.0"
+					},
+					"dependencies": {
+						"jsesc": {
+							"version": "0.5.0",
+							"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+							"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+						}
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+				},
+				"repeat-element": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+					"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+				},
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				},
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+					"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+				},
+				"restore-cursor": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"requires": {
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"ret": {
+					"version": "0.1.15",
+					"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+					"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"rsvp": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+					"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+				},
+				"run-async": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+					"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+					"requires": {
+						"is-promise": "^2.1.0"
+					}
+				},
+				"rx-lite": {
+					"version": "4.0.8",
+					"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+					"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+				},
+				"rx-lite-aggregates": {
+					"version": "4.0.8",
+					"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+					"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+					"requires": {
+						"rx-lite": "*"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+					"requires": {
+						"ret": "~0.1.10"
+					}
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+				},
+				"sane": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/sane/-/sane-3.1.0.tgz",
+					"integrity": "sha512-G5GClRRxT1cELXfdAq7UKtUsv8q/ZC5k8lQGmjEm4HcAl3HzBy68iglyNCmw4+0tiXPCBZntslHlRhbnsSws+Q==",
+					"requires": {
+						"anymatch": "^2.0.0",
+						"capture-exit": "^1.2.0",
+						"exec-sh": "^0.2.0",
+						"execa": "^1.0.0",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.3",
+						"micromatch": "^3.1.4",
+						"minimist": "^1.1.1",
+						"walker": "~1.0.5",
+						"watch": "~0.18.0"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+							"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+							"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+						},
+						"braces": {
+							"version": "2.3.2",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+							"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+							"requires": {
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						},
+						"expand-brackets": {
+							"version": "2.1.4",
+							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+							"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+							"requires": {
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "0.2.5",
+									"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+									"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+									"requires": {
+										"is-descriptor": "^0.1.0"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								},
+								"is-accessor-descriptor": {
+									"version": "0.1.6",
+									"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+									"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+									"requires": {
+										"kind-of": "^3.0.2"
+									},
+									"dependencies": {
+										"kind-of": {
+											"version": "3.2.2",
+											"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+											"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+											"requires": {
+												"is-buffer": "^1.1.5"
+											}
+										}
+									}
+								},
+								"is-data-descriptor": {
+									"version": "0.1.4",
+									"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+									"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+									"requires": {
+										"kind-of": "^3.0.2"
+									},
+									"dependencies": {
+										"kind-of": {
+											"version": "3.2.2",
+											"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+											"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+											"requires": {
+												"is-buffer": "^1.1.5"
+											}
+										}
+									}
+								},
+								"is-descriptor": {
+									"version": "0.1.6",
+									"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+									"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+									"requires": {
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
+									}
+								},
+								"kind-of": {
+									"version": "5.1.0",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+									"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+								}
+							}
+						},
+						"extend-shallow": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+							"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+							"requires": {
+								"assign-symbols": "^1.0.0",
+								"is-extendable": "^1.0.1"
+							},
+							"dependencies": {
+								"is-extendable": {
+									"version": "1.0.1",
+									"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+									"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+									"requires": {
+										"is-plain-object": "^2.0.4"
+									}
+								}
+							}
+						},
+						"extglob": {
+							"version": "2.0.4",
+							"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+							"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+							"requires": {
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+									"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+									"requires": {
+										"is-descriptor": "^1.0.0"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						},
+						"fill-range": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+							"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"is-number": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+						},
+						"micromatch": {
+							"version": "3.1.10",
+							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+							"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+							"requires": {
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
+							}
+						}
+					}
+				},
+				"sax": {
+					"version": "1.1.6",
+					"resolved": "http://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+					"integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
+				},
+				"semver": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+				},
+				"send": {
+					"version": "0.16.2",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+					"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"destroy": "~1.0.4",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "~1.6.2",
+						"mime": "1.4.1",
+						"ms": "2.0.0",
+						"on-finished": "~2.3.0",
+						"range-parser": "~1.2.0",
+						"statuses": "~1.4.0"
+					},
+					"dependencies": {
+						"mime": {
+							"version": "1.4.1",
+							"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+							"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+						},
+						"statuses": {
+							"version": "1.4.0",
+							"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+							"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+						}
+					}
+				},
+				"serialize-error": {
+					"version": "2.1.0",
+					"resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+					"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+				},
+				"serve-static": {
+					"version": "1.13.2",
+					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+					"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+					"requires": {
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"parseurl": "~1.3.2",
+						"send": "0.16.2"
+					}
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+					"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+				},
+				"shell-quote": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+					"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+					"requires": {
+						"array-filter": "~0.0.0",
+						"array-map": "~0.0.0",
+						"array-reduce": "~0.0.0",
+						"jsonify": "~0.0.0"
+					}
+				},
+				"shellwords": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+					"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+				},
+				"simple-plist": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
+					"integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
+					"requires": {
+						"bplist-creator": "0.0.7",
+						"bplist-parser": "0.1.1",
+						"plist": "2.0.1"
+					},
+					"dependencies": {
+						"base64-js": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
+							"integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg="
+						},
+						"plist": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
+							"integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os=",
+							"requires": {
+								"base64-js": "1.1.2",
+								"xmlbuilder": "8.2.2",
+								"xmldom": "0.1.x"
+							}
+						},
+						"xmlbuilder": {
+							"version": "8.2.2",
+							"resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+							"integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
+						}
+					}
+				},
+				"slide": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+					"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+					"requires": {
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+					"requires": {
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+					"requires": {
+						"kind-of": "^3.2.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				},
+				"source-map-resolve": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+					"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+					"requires": {
+						"atob": "^2.1.1",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
+					}
+				},
+				"source-map-support": {
+					"version": "0.5.9",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+						}
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+					"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+				},
+				"spdx-correct": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+					"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+					"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+					"integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+							"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+							"requires": {
+								"assign-symbols": "^1.0.0",
+								"is-extendable": "^1.0.1"
+							}
+						},
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+				},
+				"stacktrace-parser": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.4.tgz",
+					"integrity": "sha1-ATl5IuX2Ls8whFUiyVxP4dJefU4="
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+					"requires": {
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"statuses": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+					"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+				},
+				"stream-buffers": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+					"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				},
+				"temp": {
+					"version": "0.8.3",
+					"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+					"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+					"requires": {
+						"os-tmpdir": "^1.0.0",
+						"rimraf": "~2.2.6"
+					},
+					"dependencies": {
+						"rimraf": {
+							"version": "2.2.8",
+							"resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+							"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+						}
+					}
+				},
+				"throat": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+					"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+				},
+				"through": {
+					"version": "2.3.8",
+					"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+				},
+				"through2": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+					"requires": {
+						"readable-stream": "~2.3.6",
+						"xtend": "~4.0.1"
+					}
+				},
+				"time-stamp": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+					"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+				},
+				"tmp": {
+					"version": "0.0.33",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"requires": {
+						"os-tmpdir": "~1.0.2"
+					}
+				},
+				"tmpl": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+					"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+							"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+							"requires": {
+								"assign-symbols": "^1.0.0",
+								"is-extendable": "^1.0.1"
+							}
+						},
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+				},
+				"typedarray": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+				},
+				"ua-parser-js": {
+					"version": "0.7.19",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+					"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+				},
+				"uglify-es": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+					"requires": {
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.13.0",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+							"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+						},
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+						}
+					}
+				},
+				"ultron": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+					"integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+				},
+				"unicode-canonical-property-names-ecmascript": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+					"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+				},
+				"unicode-match-property-ecmascript": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+					"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+					"requires": {
+						"unicode-canonical-property-names-ecmascript": "^1.0.4",
+						"unicode-property-aliases-ecmascript": "^1.0.4"
+					}
+				},
+				"unicode-match-property-value-ecmascript": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+					"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+				},
+				"unicode-property-aliases-ecmascript": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+					"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+					"requires": {
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
+					},
+					"dependencies": {
+						"arr-union": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+							"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
+							}
+						}
+					}
+				},
+				"unpipe": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+					"requires": {
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+							"requires": {
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+									"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+							"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+					"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+				},
+				"use": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+					"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+				},
+				"utils-merge": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+					"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"vary": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+					"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+				},
+				"walker": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+					"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+					"requires": {
+						"makeerror": "1.0.x"
+					}
+				},
+				"watch": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+					"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+					"requires": {
+						"exec-sh": "^0.2.0",
+						"minimist": "^1.2.0"
+					}
+				},
+				"whatwg-fetch": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+					"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
+					}
+				},
+				"ws": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+					"integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+					"requires": {
+						"options": ">=0.0.5",
+						"ultron": "1.0.x"
+					}
+				},
+				"xcode": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/xcode/-/xcode-1.0.0.tgz",
+					"integrity": "sha1-4fWxRDJF3tOMGAeW3xoQ/e2ghOw=",
+					"requires": {
+						"pegjs": "^0.10.0",
+						"simple-plist": "^0.2.1",
+						"uuid": "3.0.1"
+					}
+				},
+				"xmlbuilder": {
+					"version": "9.0.7",
+					"resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+					"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+				},
+				"xmldoc": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
+					"integrity": "sha1-0lciS+g5PqrL+DfvIn/Y7CWzaIg=",
+					"requires": {
+						"sax": "~1.1.1"
+					}
+				},
+				"xmldom": {
+					"version": "0.1.27",
+					"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+					"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+				},
+				"xpipe": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/xpipe/-/xpipe-1.0.5.tgz",
+					"integrity": "sha1-jdi/Rfw/f1Xw4FS4ePQ6YmFNr98="
+				},
+				"xtend": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+				},
+				"yargs": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+					"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+					"requires": {
+						"camelcase": "^4.1.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"read-pkg-up": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^7.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/react-native/core/src/index.ts
+++ b/packages/react-native/core/src/index.ts
@@ -17,6 +17,7 @@
 import {
   AnonymousAuthProvider,
   AnonymousCredential,
+  BSON,
   Codec,
   CustomAuthProvider,
   CustomCredential,
@@ -61,6 +62,7 @@ import NamedServiceClientFactory from "./services/internal/NamedServiceClientFac
 import StitchServiceClient from "./services/StitchServiceClient";
 
 export {
+  BSON,
   AnonymousAuthProvider,
   AnonymousCredential,
   CustomAuthProvider,

--- a/packages/react-native/coretest/__tests__/auth/providers/userapikey/UserApiKeyAuthProviderClientIntTests.ts
+++ b/packages/react-native/coretest/__tests__/auth/providers/userapikey/UserApiKeyAuthProviderClientIntTests.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import { App, AppResponse, Userpass } from "mongodb-stitch-core-admin-client";
-import { StitchServiceErrorCode, StitchServiceError } from "mongodb-stitch-core-sdk";
+import { BSON, StitchServiceErrorCode, StitchServiceError } from "mongodb-stitch-core-sdk";
 import { UserApiKeyAuthProviderClient, UserApiKeyCredential } from "mongodb-stitch-react-native-core";
 import { BaseStitchRNIntTestHarness } from "mongodb-stitch-react-native-testutils";
 

--- a/packages/react-native/sdk/README.md
+++ b/packages/react-native/sdk/README.md
@@ -11,7 +11,7 @@ The official [MongoDB Stitch](https://stitch.mongodb.com/) React Native SDK for 
 - [Example Usage](#example-usage)
 
 ## Documentation
-* [API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js-react-native/docs/4.1.0/index.html)
+* [API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js-react-native/docs/4.1.2/index.html)
 * [MongoDB Stitch Documentation](https://docs.mongodb.com/stitch/)
 
 ## Discussion
@@ -189,6 +189,21 @@ client.auth.loginWithCredential(new AnonymousCredential()).then(user => {
 ```
 logging in anonymously                                                    	
 logged in anonymously as user 58c5d6ebb9ede022a3d75050
+```
+
+#### Using BSON and Extended JSON
+
+This library depends on [js-bson](https://www.npmjs.com/package/js-bson).
+
+As a convenience, the SDK includes the `BSON` library, and you can import it as you would import other classes and values from the SDK.
+
+Here is an example of importing BSON to generate a BSON `ObjectID`:
+
+```javascript
+import { BSON } from 'mongodb-stitch-react-native-sdk';
+
+let myObjectId = new BSON.ObjectId();
+console.log(`Generated ObjectId: ${myObjectId}`);
 ```
 
 #### Executing a function

--- a/packages/react-native/services/aws-s3/__tests__/AwsS3ServiceClientIntTests.ts
+++ b/packages/react-native/services/aws-s3/__tests__/AwsS3ServiceClientIntTests.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import {
   Anon,
   App,
@@ -25,6 +24,7 @@ import {
   Service
 } from "mongodb-stitch-core-admin-client";
 import {
+  BSON,
   FetchTransport,
   Method,
   StitchServiceError,

--- a/packages/react-native/services/aws/__tests__/AwsServiceClientIntTests.ts
+++ b/packages/react-native/services/aws/__tests__/AwsServiceClientIntTests.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import {
   Anon,
   App,
@@ -24,6 +23,7 @@ import {
   Service
 } from "mongodb-stitch-core-admin-client";
 import {
+  BSON,
   FetchTransport,
   Method,
   StitchServiceError,

--- a/packages/server/core/src/index.ts
+++ b/packages/server/core/src/index.ts
@@ -17,6 +17,7 @@
 import {
   AnonymousAuthProvider,
   AnonymousCredential,
+  BSON,
   Codec,
   CustomAuthProvider,
   CustomCredential,
@@ -60,6 +61,7 @@ import NamedServiceClientFactory from "./services/internal/NamedServiceClientFac
 import StitchServiceClient from "./services/StitchServiceClient";
 
 export {
+  BSON,
   AnonymousAuthProvider,
   AnonymousCredential,
   CustomAuthProvider,

--- a/packages/server/coretest/__tests__/auth/providers/userapikey/UserApiKeyAuthProviderClientIntTests.ts
+++ b/packages/server/coretest/__tests__/auth/providers/userapikey/UserApiKeyAuthProviderClientIntTests.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import { App, AppResponse, Userpass } from "mongodb-stitch-core-admin-client";
-import { StitchServiceErrorCode, StitchServiceError } from "mongodb-stitch-core-sdk";
+import { BSON, StitchServiceErrorCode, StitchServiceError } from "mongodb-stitch-core-sdk";
 import { UserApiKeyAuthProviderClient, UserApiKeyCredential } from "mongodb-stitch-server-core";
 import { BaseStitchServerIntTestHarness } from "mongodb-stitch-server-testutils";
 

--- a/packages/server/sdk/README.md
+++ b/packages/server/sdk/README.md
@@ -126,7 +126,7 @@ As a convenience, the SDK includes the `BSON` library, and you can import it as 
 Here is an example of importing BSON to generate a BSON `ObjectID`:
 
 ```javascript
-import { BSON } from 'mongodb-stitch-server-sdk';
+const { BSON } = require('mongodb-stitch-server-sdk');
 
 let myObjectId = new BSON.ObjectId();
 console.log(`Generated ObjectId: ${myObjectId}`);

--- a/packages/server/sdk/README.md
+++ b/packages/server/sdk/README.md
@@ -11,7 +11,7 @@ The official [MongoDB Stitch](https://stitch.mongodb.com/) Server SDK for JavaSc
 - [Example Usage](#example-usage)
 
 ## Documentation
-* [API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js-server/docs/4.1.0/index.html)
+* [API/Typedoc Documentation](https://s3.amazonaws.com/stitch-sdks/js-server/docs/4.1.2/index.html)
 * [MongoDB Stitch Documentation](https://docs.mongodb.com/stitch/)
 
 ## Discussion
@@ -115,6 +115,21 @@ client.auth.loginWithCredential(new AnonymousCredential()).then(user => {
 ```
 logging in anonymously                                                    	
 logged in anonymously as user 58c5d6ebb9ede022a3d75050
+```
+
+#### Using BSON and Extended JSON
+
+This library depends on [js-bson](https://www.npmjs.com/package/js-bson).
+
+As a convenience, the SDK includes the `BSON` library, and you can import it as you would import other classes and values from the SDK.
+
+Here is an example of importing BSON to generate a BSON `ObjectID`:
+
+```javascript
+import { BSON } from 'mongodb-stitch-server-sdk';
+
+let myObjectId = new BSON.ObjectId();
+console.log(`Generated ObjectId: ${myObjectId}`);
 ```
 
 #### Executing a function

--- a/packages/server/services/aws-s3/__tests__/AwsS3ServiceClientIntTests.ts
+++ b/packages/server/services/aws-s3/__tests__/AwsS3ServiceClientIntTests.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import {
   Anon,
   App,
@@ -25,6 +24,7 @@ import {
   Service
 } from "mongodb-stitch-core-admin-client";
 import {
+  BSON,
   FetchTransport,
   Method,
   StitchServiceError,

--- a/packages/server/services/aws/__tests__/AwsServiceClientIntTests.ts
+++ b/packages/server/services/aws/__tests__/AwsServiceClientIntTests.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import {
   Anon,
   App,
@@ -24,6 +23,7 @@ import {
   Service
 } from "mongodb-stitch-core-admin-client";
 import {
+  BSON,
   FetchTransport,
   Method,
   StitchServiceError,

--- a/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import BSON from "bson";
 import {
   Anon,
   App,
@@ -26,6 +25,7 @@ import {
 } from "mongodb-stitch-core-admin-client";
 import {
   AnonymousCredential,
+  BSON,
   Codec,
   StitchServiceError,
   StitchServiceErrorCode


### PR DESCRIPTION
Without the `package-lock.json` changes this PR is tiny.

Changes:
* imports `BSON from "bson"` and exports it at the `mongodb-stitch-core-sdk` level
* exports this `BSON` at the `mongodb-stitch-browser-core`, `mongodb-stitch-react-native-core`, and `mongodb-stitch-server-core` levels.
    * all of the `*-sdk` modules get this `BSON` automatically because those modules `import * from` their respective core module.
* changed `BSON` imports in integration tests to be from Stitch modules rather than from `"bson"`

I've also verified that `BSON` is usable in the generated `stitch.js` for use in script tags.