### PR TITLE
DOCSP-3937 Add analytics snippet to all SDK pages

### DIFF
--- a/contrib/generate_docs.sh
+++ b/contrib/generate_docs.sh
@@ -1,0 +1,72 @@
+#!/bin/bash -e
+
+function usage() {
+    echo "Usage: $0 <browser|server|react-native> [analytics]"
+    exit 1
+}
+
+cd "$(dirname "$0")"/..
+
+while getopts "h?vf:" opt; do
+    case "$opt" in
+    h|\?)
+        show_help
+        exit 0
+        ;;
+    v)  verbose=1
+        ;;
+    f)  output_file=$OPTARG
+        ;;
+    esac
+done
+
+if [[ ! -d "typedoc-theme/bin/" ]]; then
+    npm run docs-theme
+fi
+
+sdk="$1"
+
+if [ -z "$sdk" ]; then
+    usage
+fi
+
+case "$sdk" in
+    browser)
+        pretty_name="Browser"
+        ;;
+    server)
+        pretty_name="Server"
+        ;;
+    react-native)
+        pretty_name="React Native"
+        ;;
+    *)
+        echo "Unrecognized SDK: $sdk"
+        usage
+        ;;
+esac
+
+# Co-opting gaID flag because Typedoc does not currently allow arbitrary settings 
+# and we don't want to put analytics on local docs builds. The second parameter
+# is optional.
+if [ "$2" == "analytics" ]; then
+    gaID="--gaID 1"
+elif [[ ! -z "$2" ]]; then
+    echo "Unrecognized argument: $2"
+    usage
+fi
+
+typedoc \
+    --name "MongoDB Stitch $pretty_name SDK" \
+    --out ./docs-$sdk \
+    --mode file \
+    --tsconfig config/tdconfig.$sdk.json \
+    --readme packages/$sdk/sdk/README.md \
+        packages/$sdk/core/src/index.ts \
+        packages/core/sdk/src/index.ts \
+        packages/core/services/*/src/index.ts \
+        packages/$sdk/services/*/src/index.ts \
+    --ignoreCompilerErrors \
+    --excludeNotExported \
+    --theme typedoc-theme/bin/ \
+    $gaID

--- a/contrib/publish_docs.sh
+++ b/contrib/publish_docs.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+cd "$(dirname "$0")"
+
 VERSION=`node -e 'console.log(require("../lerna.json").version)'` 
 VERSION_MAJOR=$(echo $VERSION | cut -d. -f1)
 VERSION_MINOR=$(echo $VERSION | cut -d. -f2)
@@ -9,7 +11,10 @@ VERSION_PATCH=$(echo $VERSION | cut -d. -f3 | cut -d- -f1)
 VERSION_QUALIFIER=$(echo $VERSION | cut -d- -f2 -s)
 VERSION_QUALIFIER_INC=$(echo $VERSION | cut -d- -f3 -s)
 
-npm run docs
+# Generate the docs with the analytics script enabled.
+./generate_docs browser analytics
+./generate_docs server analytics
+./generate_docs react-native analytics
 
 if ! which aws; then
    echo "aws CLI not found. see: https://docs.aws.amazon.com/cli/latest/userguide/installing.html"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "stitch-js-sdk",
 	"private": true,
 	"devDependencies": {
 		"@types/jest": "^23.1.0",
@@ -24,9 +25,9 @@
 	"scripts": {
 		"docs": "npm run docs-theme && npm run docs-browser && npm run docs-server && npm run docs-react-native",
     "docs-theme": "pushd typedoc-theme && npm run build",
-		"docs-browser": "typedoc --name 'MongoDB Stitch Browser SDK' --out ./docs-browser --mode file --tsconfig config/tdconfig.browser.json --readme packages/browser/sdk/README.md  packages/browser/core/src/index.ts packages/core/sdk/src/index.ts packages/core/services/*/src/index.ts packages/browser/services/*/src/index.ts --ignoreCompilerErrors --excludeNotExported --theme typedoc-theme/bin/",
-		"docs-server": "typedoc --name 'MongoDB Stitch Server SDK' --out ./docs-server --mode file --tsconfig config/tdconfig.server.json --readme packages/server/sdk/README.md  packages/server/core/src/index.ts packages/core/sdk/src/index.ts packages/core/services/*/src/index.ts packages/server/services/*/src/index.ts --ignoreCompilerErrors --excludeNotExported --theme typedoc-theme/bin/",
-		"docs-react-native": "typedoc --name 'MongoDB Stitch React Native SDK' --out ./docs-react-native --mode file --tsconfig config/tdconfig.react-native.json --readme packages/react-native/sdk/README.md  packages/react-native/core/src/index.ts packages/core/sdk/src/index.ts packages/core/services/*/src/index.ts packages/react-native/services/*/src/index.ts --ignoreCompilerErrors --excludeNotExported --theme typedoc-theme/bin/",
+		"docs-browser": "./contrib/generate_docs.sh browser",
+		"docs-server": "./contrib/generate_docs.sh server",
+		"docs-react-native": "./contrib/generate_docs.sh react-native",
 		"test:coverage": "lcov-result-merger 'packages/**/lcov.info' | PATH=$(npm bin):$PATH coveralls"
 	}
 }

--- a/typedoc-theme/src/partials/analytics.hbs
+++ b/typedoc-theme/src/partials/analytics.hbs
@@ -1,0 +1,11 @@
+{{#if settings.gaID}} 
+<script>
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+  analytics.load("aGhVvyxnPWlyP71vVl9ZjGWxAtoVGLXX");
+  analytics.page({
+    project: 'stitch-js-sdk',
+    branch: 'v4.2',
+  });
+  }}();
+</script>
+{{/if}}


### PR DESCRIPTION
This injects the Segment analytics snippet to all pages via
the custom TypeDoc theme.

Adds a script for building the docs so that analytics are only
added when publishing docs, and not for local docs builds.