### PR TITLE
DOCSP-4282 Copy changes in browser to server, RN docs

### DIFF
--- a/packages/browser/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/browser/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -51,17 +51,25 @@ import RemoteMongoReadOperation from "./RemoteMongoReadOperation";
  *
  * Here's how to access a database and one of its collections:
  * ```
- * // Instantiate the Stitch client
- * const stitchClient = Stitch.initializeDefaultAppClient('your-stitch-app-id')
- *
+ * // Assumption: Stitch client has been initialized and is already logged in.
+ * 
+ * // Get the existing Stitch client.
+ * const stitchClient = Stitch.defaultAppClient
+ * 
  * // Get a client of the Remote Mongo Service for database access
  * const mongoClient = stitchClient.getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
- *
+ * 
  * // Retrieve a database object
- * const exampleDb = mongoClient.db('example-db')
- *
+ * const db = mongoClient.db('video')
+ * 
  * // Retrieve the collection in the database
- * const exampleCollection = db.collection('example-collection')
+ * const movieDetails = db.collection('movieDetails')
+ * 
+ * // Find 10 documents and log them to console.
+ * movieDetails.find({}, {limit: 10})
+ *   .toArray()
+ *   .then(results => console.log('Results:', results))
+ *   .catch(console.error)
  * ```
  *
  * For more examples, see [CRUD Snippets](https://docs.mongodb.com/stitch/mongodb/crud-snippets/)

--- a/packages/core/sdk/src/auth/StitchCredential.ts
+++ b/packages/core/sdk/src/auth/StitchCredential.ts
@@ -22,13 +22,12 @@ import ProviderCapabilities from "./ProviderCapabilities";
  * Pass implementations to [[StitchAuth.loginWithCredential]] to log in as a [[StitchUser]].
  * 
  * Each [Authentication Provider](https://docs.mongodb.com/stitch/authentication/)
- * in MongoDB Stitch provides a StitchCredential or [[StitchRedirectCredential]]
+ * in MongoDB Stitch provides a StitchCredential or StitchRedirectCredential (browser SDK only)
  * implementation. See **Implemented by** below for a list of implementations.
  *
  * ### See also
  * - [[StitchAuth]]
- * - [[StitchAuth.loginWithCredential]] 
- * - [[StitchRedirectCredential]]
+ * - [[StitchAuth.loginWithCredential]]
  */
 export default interface StitchCredential {
   /**

--- a/packages/react-native/core/src/core/Stitch.ts
+++ b/packages/react-native/core/src/core/Stitch.ts
@@ -27,12 +27,23 @@ const DEFAULT_BASE_URL = "https://stitch.mongodb.com";
 const appClients: { [key: string]: StitchAppClientImpl } = {};
 
 /**
- * Singleton class with static utility functions for initializing the MongoDB 
- * Stitch Browser SDK, and for retrieving a {@link StitchAppClient}.
+ * Singleton class with static utility functions for initializing a [[StitchAppClient]].
+ *
+ * Typically, the [[Stitch.initializeDefaultAppClient]] method is all you need 
+ * to instantiate the client:
+ * 
+ * ```
+ * const client = Stitch.initializeDefaultAppClient('your-stitch-app-id')
+ * ```
+ *
+ * For custom configurations, see [[Stitch.initializeAppClient]] and [[StitchAppClientConfiguration]].
+ *
+ * ### See also
+ * - [[StitchAppClient]]
  */
 export default class Stitch {
   /**
-   * Retrieves the default StitchAppClient associated with the application.
+   * Retrieves the default [[StitchAppClient]] associated with the application.
    */
   public static get defaultAppClient(): StitchAppClient {
     if (Stitch.defaultClientAppId === undefined) {
@@ -42,7 +53,7 @@ export default class Stitch {
   }
 
   /**
-   * Retrieves the StitchAppClient associated with the specified client app id.
+   * Retrieves the [[StitchAppClient]] associated with the specified client app id.
    * @param clientAppId The client app id of the desired app client.
    */
   public static getAppClient(clientAppId: string): StitchAppClient {
@@ -55,8 +66,8 @@ export default class Stitch {
   }
 
   /**
-   * Returns whether or not a StitchAppClient has been initialized for the
-   * specified clientAppId
+   * Returns whether or not a [[StitchAppClient]] has been initialized for the
+   * specified clientAppId.
    * 
    * @param clientAppId The client app id to check for.
    */
@@ -65,7 +76,7 @@ export default class Stitch {
   }
 
   /**
-   * Initializes the default StitchAppClient associated with the application.
+   * Initializes the default [[StitchAppClient]] associated with the application.
    * 
    * @param clientAppId The desired clientAppId for the client.
    * @param config Additional configuration options (optional).
@@ -94,11 +105,11 @@ export default class Stitch {
   }
 
   /**
-   * Initializes a new, non-default StitchAppClient associated with the 
+   * Initializes a new, non-default [[StitchAppClient]] associated with the 
    * application.
    * 
    * @param clientAppId The desired clientAppId for the client.
-   * @param config Additional configuration options (optional).
+   * @param config Additional [[StitchAppClientConfiguration]] options (optional).
    * @returns A Promise resolving to an initialized StitchAppClient.
    */
   public static initializeAppClient(

--- a/packages/react-native/core/src/core/StitchAppClient.ts
+++ b/packages/react-native/core/src/core/StitchAppClient.ts
@@ -20,20 +20,34 @@ import StitchServiceClient from "../services/StitchServiceClient";
 import StitchAuth from "./auth/StitchAuth";
 
 /**
- * The fundamental set of methods for communicating with a MongoDB Stitch 
- * application. Contains methods for executing Stitch functions and retrieving 
- * clients for Stitch services, and contains a `StitchAuth` object to manage 
- * the authentication state of the client. An implementation can be 
- * instantiated using the `Stitch` utility class.
+ * The StitchAppClient is the interface to a MongoDB Stitch App backend.
+ *
+ * It is created by the [[Stitch]] singleton.
+ *
+ * The StitchAppClient holds a [[StitchAuth]] object for managing the login state of the client.
+ *
+ * It provides clients for [Stitch Services](https://docs.mongodb.com/stitch/services/) including
+ * the [[RemoteMongoClient]] for database and collection access.
+ *
+ * Finally, the StitchAppClient can execute [Stitch Functions](https://docs.mongodb.com/stitch/functions/).
+ *
+ * ### Example
+ * ```
+ * import { Stitch } from "mongodb-stitch-browser-sdk"
+ * 
+ * const client = Stitch.initializeDefaultAppClient('example-stitch-app-id')
+ * ```
+ * 
+ * ### See also
+ * - [[Stitch]]
+ * - [[StitchAuth]]
+ * - [[RemoteMongoClient]]
+ * - [Stitch Functions](https://docs.mongodb.com/stitch/functions/)
  */
 export default interface StitchAppClient {
   /**
-   * The {@link StitchAuth} object representing the authentication state of 
-   * this client. Includes methods for logging in and logging out.
-   *
-   * Authentication state can be persisted beyond the lifetime of a browser 
-   * session. A StitchAppClient retrieved from the `Stitch` singleton may or 
-   * may not be already authenticated when first initialized.
+   * The [[StitchAuth]] object representing the login state of this client.
+   * Includes methods for logging in and logging out.
    */
   auth: StitchAuth;
 

--- a/packages/react-native/core/src/core/auth/StitchAuth.ts
+++ b/packages/react-native/core/src/core/auth/StitchAuth.ts
@@ -21,25 +21,44 @@ import StitchAuthListener from "./StitchAuthListener";
 import StitchUser from "./StitchUser";
 
 /**
- * A set of methods for retrieving or modifying the authentication state of a 
- * {@link StitchAppClient}. An implementation can be instantiated with a 
- * {@link StitchAppClient} instance.
+ * StitchAuth represents and controls the login state of a [[StitchAppClient]]. 
+ *
+ * Login is required for most Stitch functionality. Decide which
+ * [Authentication Provider](https://docs.mongodb.com/stitch/authentication/)
+ * you are using and use [[loginWithCredential]] to log in.
+ *
+ * Once logged in, [[StitchAuth.user]] is a [[StitchUser]] object that can be examined for 
+ * user profile and other information.
+ * 
+ * Login state can persist across browser sessions. Therefore, a StitchAppClient's
+ * StitchAuth instance may already contain login information upon initialization.
+ *
+ * To log out, use [[logout]].
+ *
+ * ### Examples
+ *
+ * For an example of [[loginWithCredential]], see [Anonymous Authentication](https://docs.mongodb.com/stitch/authentication/anonymous/).
+ *
+ * ### See also
+ * - [Users](https://docs.mongodb.com/stitch/users/)
+ * - [Authentication](https://docs.mongodb.com/stitch/authentication/)
+ * - [[StitchAppClient]]
+ * - [[StitchUser]]
  */
 export default interface StitchAuth {
   /**
-   * Whether or not the client containing this `StitchAuth` object is currently 
-   * authenticated.
+   * Whether or not the [[StitchAppClient]] containing this StitchAuth object 
+   * is currently logged in.
    */
   isLoggedIn: boolean;
 
   /**
-   * A {@link StitchUser} object representing the user that the client is 
-   * currently authenticated as. `undefined` if the client is not currently 
-   * authenticated.
+   * A [[StitchUser]] object representing who the client is currently logged in as,
+   * or `undefined` if the client is not currently logged in.
    */
   user?: StitchUser;
 
-  /**
+  /** @hidden
    * Retrieves the authentication provider client for the authentication 
    * provider associated with the specified factory.
    * 
@@ -49,7 +68,7 @@ export default interface StitchAuth {
     factory: AuthProviderClientFactory<ClientT>
   ): ClientT;
 
-  /**
+  /** @hidden
    * Retrieves the authentication provider client for the authentication 
    * provider associated with the specified factory and auth provider name.
    * 
@@ -61,10 +80,14 @@ export default interface StitchAuth {
   ): T;
 
   /**
-   * Authenticates the client as a MongoDB Stitch user using the provided 
-   * {@link StitchCredential}.
+   * Logs in as a [[StitchUser]] using the provided [[StitchCredential]].
    * 
-   * @param credential The credential to use when logging in.
+   * For an example of the most simple form of authentication, see
+   * [Anonymous Authentication](https://docs.mongodb.com/stitch/authentication/anonymous/).
+   *
+   * For another example, see [Email/Password Authentication](https://docs.mongodb.com/stitch/authentication/userpass/).
+   *
+   * @param credential The [[StitchCredential]] to use when logging in.
    */
   loginWithCredential(credential: StitchCredential): Promise<StitchUser>;
 
@@ -75,7 +98,7 @@ export default interface StitchAuth {
   logout(): Promise<void>;
 
   /**
-   * Registers a {@link StitchAuthListener} with the client.
+   * Registers a [[StitchAuthListener]] with the client.
    * @param listener The listener to be triggered when an authentication event
    * occurs on this auth object.
    */

--- a/packages/react-native/core/src/core/auth/StitchUser.ts
+++ b/packages/react-native/core/src/core/auth/StitchUser.ts
@@ -21,9 +21,14 @@ import {
   StitchUserProfile } from "mongodb-stitch-core-sdk";
     
 /**
- * A user that a {@link StitchAppClient} is currently authenticated as.
- * Can be retrieved from a {@link StitchAuth} or from the result of certain 
- * methods.
+ * The StitchUser represents the currently logged-in user of the [[StitchAppClient]].
+ * 
+ * This can be retrieved from [[StitchAuth]] or from the result of certain methods
+ * such as [[StitchAuth.loginWithCredential]].
+ *
+ * ### See also
+ * - [[StitchAuth]]
+ * - [[StitchCredential]]
  */
 export default interface StitchUser extends CoreStitchUser {
   /**

--- a/packages/react-native/services/mongodb-remote/src/RemoteMongoClient.ts
+++ b/packages/react-native/services/mongodb-remote/src/RemoteMongoClient.ts
@@ -26,15 +26,38 @@ import RemoteMongoClientImpl from "./internal/RemoteMongoClientImpl";
 import RemoteMongoDatabase from "./RemoteMongoDatabase";
 
 /**
- * A client which can be used to get database and collection objects which can 
- * be used to interact with MongoDB data via the Stitch MongoDB service.
+ * The RemoteMongoClient can be used to get database and collection objects
+ * for interacting with MongoDB data via the Stitch MongoDB service.
+ *
+ * Service clients are created with [[StitchAppClient.getServiceClient]] by passing
+ * [[RemoteMongoClient.factory]] and the "Stitch Service Name" found under _Clusters_
+ * in the [Stitch control panel](https://stitch.mongodb.com)
+ * ("mongodb-atlas" by default).
+ *
+ * Once the RemoteMongoClient is instantiated, you can use the [[db]] method to access
+ * a [[RemoteMongoDatabase]]. A RemoteMongoDatabase will then provide access to
+ * a [[RemoteMongoCollection]], where you can read and write data.
+ *
+ * Note: The client needs to log in (at least anonymously) to use the database.
+ * See [[StitchAuth]].
+ * 
+ * ### Example
+ * ```
+ * const stitchClient = Stitch.initializeDefaultAppClient('your-stitch-app-id')
+ * const mongoClient = stitchClient.getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
+ * ```
+ *
+ *
+ * ### See also
+ * - [[StitchAppClient]]
+ * - [[RemoteMongoDatabase]]
  */
 export interface RemoteMongoClient {
   /**
-   * Gets a {@link RemoteMongoDatabase} instance for the given database name.
+   * Gets a [[RemoteMongoDatabase]] instance for the given database name.
    *
    * @param name the name of the database to retrieve
-   * @return a {@code RemoteMongoDatabase} representing the specified database
+   * @return a [[RemoteMongoDatabase]] representing the specified database
    */
   db(name: string): RemoteMongoDatabase;
 }

--- a/packages/react-native/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/react-native/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -28,8 +28,59 @@ import {
 import RemoteMongoReadOperation from "./RemoteMongoReadOperation";
 
 /**
- * An interface representing a MongoDB collection accesible via the Stitch 
- * MongoDB service.
+ * The RemoteMongoCollection is the interface to a MongoDB database's
+ * collection via Stitch, allowing read and write.
+ *
+ * It is retrieved from a [[RemoteMongoDatabase]].
+ *
+ * The read operations are [[find]], [[count]] and [[aggregate]].
+ *
+ * The write operations are [[insertOne]], [[insertMany]], 
+ * [[updateOne]], [[updateMany]], [[deleteOne]], and [[deleteMany]].
+ *
+ * If you are already familiar with MongoDB drivers, it is important
+ * to understand that the RemoteMongoCollection only provides access
+ * to the operations available in Stitch. For a list of unsupported
+ * aggregation stages, see 
+ * [Unsupported Aggregation Stages](https://docs.mongodb.com/stitch/mongodb/actions/collection.aggregate/#unsupported-aggregation-stages).
+ *
+ * ### Example
+ *
+ * Here's how to access a database and one of its collections:
+ * ```
+ * // Assumption: Stitch client has been initialized and is already logged in.
+ * 
+ * // Get the existing Stitch client.
+ * const stitchClient = Stitch.defaultAppClient
+ * 
+ * // Get a client of the Remote Mongo Service for database access
+ * const mongoClient = stitchClient.getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
+ * 
+ * // Retrieve a database object
+ * const db = mongoClient.db('video')
+ * 
+ * // Retrieve the collection in the database
+ * const movieDetails = db.collection('movieDetails')
+ * 
+ * // Find 10 documents and log them to console.
+ * movieDetails.find({}, {limit: 10})
+ *   .toArray()
+ *   .then(results => console.log('Results:', results))
+ *   .catch(console.error)
+ * ```
+ *
+ * For more examples, see [CRUD Snippets](https://docs.mongodb.com/stitch/mongodb/crud-snippets/)
+ * on the MongoDB Stitch Documentation site.
+ *
+ * ### Note: Log in first
+ *
+ * A user will need to be logged in (at least anonymously) before you can read from
+ * or write to the collection. See [[StitchAuth]].
+ * 
+ * ### See also
+ * - [[RemoteMongoClient]]
+ * - [[RemoteMongoDatabase]]
+ * - [CRUD Snippets](https://docs.mongodb.com/stitch/mongodb/crud-snippets/)
  */
 export default interface RemoteMongoCollection<DocumentT> {
   /**
@@ -40,7 +91,7 @@ export default interface RemoteMongoCollection<DocumentT> {
   readonly namespace: string;
 
   /**
-   * Create a new emoteMongoCollection instance with a different default class to cast any
+   * Create a new RemoteMongoCollection instance with a different default class to cast any
    * documents returned from the database into.
    *
    * @param codec the default class to cast any documents returned from the database into.
@@ -60,7 +111,9 @@ export default interface RemoteMongoCollection<DocumentT> {
   count(query?: object, options?: RemoteCountOptions): Promise<number>;
 
   /**
-   * Finds all documents in the collection.
+   * Finds all documents in the collection that match the given query.
+   * 
+   * An empty query (`{}`) will match all documents.
    *
    * @param query the query filter
    * @return a read operation which can be used to execute the query
@@ -72,6 +125,10 @@ export default interface RemoteMongoCollection<DocumentT> {
 
   /**
    * Aggregates documents according to the specified aggregation pipeline.
+   *
+   * Stitch supports a subset of the available aggregation stages in MongoDB.
+   * See 
+   * [Unsupported Aggregation Stages](https://docs.mongodb.com/stitch/mongodb/actions/collection.aggregate/#unsupported-aggregation-stages).
    *
    * @param pipeline the aggregation pipeline
    * @return a read operation which can be used to execute the aggregation
@@ -96,9 +153,8 @@ export default interface RemoteMongoCollection<DocumentT> {
   insertMany(documents: DocumentT[]): Promise<RemoteInsertManyResult>;
 
   /**
-   * Removes at most one document from the collection that matches the given filter.  If no
-   * documents match, the collection is not
-   * modified.
+   * Removes at most one document from the collection that matches the given filter.
+   * If no documents match, the collection is not modified.
    *
    * @param query the query filter to apply the the delete operation
    * @return a Promise containing the result of the remove one operation

--- a/packages/react-native/services/mongodb-remote/src/RemoteMongoCursor.ts
+++ b/packages/react-native/services/mongodb-remote/src/RemoteMongoCursor.ts
@@ -15,9 +15,35 @@
  */
 
 /**
- * A cursor of documents which can be traversed asynchronously. A 
- * {@link RemoteMongoCursor} can be the result of a `find` or
- * `aggregate` operation on a {@link RemoteMongoReadOperation}.
+ * RemoteMongoCursor is an iterator over documents, which allows asynchronous traversal.
+ *
+ * A RemoteMongoCursor can be obtained from the result of a `find` or `aggregate` operation
+ * on a [[RemoteMongoCollection]] by calling [[RemoteMongoReadOperation.iterator]].
+ *
+ * ### Example
+ *
+ * This example shows how to iterate using a cursor and async/await.
+ * ```
+ * // Work with the movies collection
+ * const moviesCollection = db.collection('movieDetails')
+ *
+ * moviesCollection
+ *   .find({}, {limit: 100})
+ *   .iterator()
+ *   .then(async (cursor) => {
+ *     let movie = await cursor.next()
+ *     while (movie !== undefined) {
+ *       console.log(movie)
+ *       movie = await cursor.next()
+ *     }
+ *   })
+ * ```
+ * 
+ * ### See also
+ * - [[RemoteMongoCollection.find]]
+ * - [[RemoteMongoCollection.aggregate]]
+ * - [[RemoteMongoReadOperation]]
+ * - [[RemoteMongoReadOperation.iterator]]
  */
 export default class RemoteMongoCursor<T> {
   constructor(

--- a/packages/react-native/services/mongodb-remote/src/RemoteMongoDatabase.ts
+++ b/packages/react-native/services/mongodb-remote/src/RemoteMongoDatabase.ts
@@ -18,8 +18,34 @@ import { Codec } from "mongodb-stitch-core-sdk";
 import RemoteMongoCollection from "./RemoteMongoCollection";
 
 /**
- * An interface representing a MongoDB database accesible via the Stitch 
- * MongoDB service.
+ * RemoteMongoDatabase provides access to a MongoDB database.
+ * 
+ * It is instantiated by [[RemoteMongoClient]].
+ *
+ * Once instantiated, it can be used to access a [[RemoteMongoCollection]]
+ * for reading and writing data.
+ *
+ * ### Example
+ *
+ * Here's how to access a database and one of its collections:
+ * ```
+ * // Instantiate the Stitch client
+ * const stitchClient = Stitch.initializeDefaultAppClient('your-stitch-app-id')
+ *
+ * // Get a client of the Remote Mongo Service for database access
+ * const mongoClient = stitchClient.getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
+ *
+ * // Retrieve a database object
+ * const exampleDb = mongoClient.db('example-db')
+ * 
+ * // Retrieve the collection in the database
+ * const exampleCollection = db.collection('example-collection')
+ * ```
+ *
+ * ### See also
+ * - [[RemoteMongoClient]]
+ * - [[RemoteMongoCollection]]
+ * 
  */
 export default interface RemoteMongoDatabase {
   /**

--- a/packages/react-native/services/mongodb-remote/src/RemoteMongoReadOperation.ts
+++ b/packages/react-native/services/mongodb-remote/src/RemoteMongoReadOperation.ts
@@ -18,11 +18,38 @@ import { CoreRemoteMongoReadOperation } from "mongodb-stitch-core-services-mongo
 import RemoteMongoCursor from "./RemoteMongoCursor";
 
 /**
- * Represents a `find` or `aggregate` operation against a MongoDB collection. 
- * Use the methods in this class to execute the operation and retrieve the results.
+ * Represents a `find` or `aggregate` operation against a [[RemoteMongoCollection]].
+ * 
+ * The methods in this class execute the operation and retrieve the results,
+ * either as an [[iterator]] or all in one array with [[toArray]].
+ *
+ * ### Example
+ *
+ * This example finds 10 documents from the example collection. It assumes a user is
+ * already logged in -- see [[StitchAuth]] for more information on logging in.
+ * ```
+ * // Assumption: Stitch is already logged in
+ * 
+ * const exampleCollection = db.collection('example-collection')
+ * 
+ * exampleCollection
+ *   .find({}, { limit: 10 })   // find() returns a RemoteMongoReadOperation.
+ *   .toArray()                 // Read all results as an array.
+ *   .then(documents => console.log('Documents:', documents)) // If successful, log each document to console.
+ *   .catch(console.error)      // Otherwise, log any errors to the error console.
+ * ```
+ * 
+ * ### See also
+ * - [[RemoteMongoCollection]]
+ * - [[RemoteMongoCollection.find]]
+ * - [[RemoteMongoCollection.aggregate]]
+ * - [[RemoteFindOptions]]
+ * - [CRUD Snippets](https://docs.mongodb.com/stitch/mongodb/crud-snippets/#find)
  */
 export default class RemoteMongoReadOperation<T> {
+  /** @hidden */
   constructor(
+    /** @hidden */
     private readonly proxy: CoreRemoteMongoReadOperation<T>
   ) {}
 

--- a/packages/server/core/src/core/Stitch.ts
+++ b/packages/server/core/src/core/Stitch.ts
@@ -31,12 +31,23 @@ const DEFAULT_STITCH_DIR = ".stitch/apps";
 const appClients: { [key: string]: StitchAppClientImpl } = {};
 
 /**
- * Singleton class with static utility functions for initializing the MongoDB 
- * Stitch Browser SDK, and for retrieving a {@link StitchAppClient}.
+ * Singleton class with static utility functions for initializing a [[StitchAppClient]].
+ *
+ * Typically, the [[Stitch.initializeDefaultAppClient]] method is all you need 
+ * to instantiate the client:
+ * 
+ * ```
+ * const client = Stitch.initializeDefaultAppClient('your-stitch-app-id')
+ * ```
+ *
+ * For custom configurations, see [[Stitch.initializeAppClient]] and [[StitchAppClientConfiguration]].
+ *
+ * ### See also
+ * - [[StitchAppClient]]
  */
 export default class Stitch {
   /**
-   * Retrieves the default StitchAppClient associated with the application.
+   * Retrieves the default [[StitchAppClient]] associated with the application.
    */
   public static get defaultAppClient(): StitchAppClient {
     if (Stitch.defaultClientAppId === undefined) {
@@ -46,7 +57,7 @@ export default class Stitch {
   }
 
   /**
-   * Retrieves the StitchAppClient associated with the specified client app id.
+   * Retrieves the [[StitchAppClient]] associated with the specified client app id.
    * @param clientAppId The client app id of the desired app client.
    */
   public static getAppClient(clientAppId: string): StitchAppClient {
@@ -59,8 +70,8 @@ export default class Stitch {
   }
 
   /**
-   * Returns whether or not a StitchAppClient has been initialized for the
-   * specified clientAppId
+   * Returns whether or not a [[StitchAppClient]] has been initialized for the
+   * specified clientAppId.
    * 
    * @param clientAppId The client app id to check for.
    */
@@ -69,7 +80,7 @@ export default class Stitch {
   }
 
   /**
-   * Initializes the default StitchAppClient associated with the application.
+   * Initializes the default [[StitchAppClient]] associated with the application.
    * 
    * @param clientAppId The desired clientAppId for the client.
    * @param config Additional configuration options (optional).
@@ -94,11 +105,11 @@ export default class Stitch {
   }
 
   /**
-   * Initializes a new, non-default StitchAppClient associated with the 
+   * Initializes a new, non-default [[StitchAppClient]] associated with the 
    * application.
    * 
    * @param clientAppId The desired clientAppId for the client.
-   * @param config Additional configuration options (optional).
+   * @param config Additional [[StitchAppClientConfiguration]] options (optional).
    */
   public static initializeAppClient(
     clientAppId: string,

--- a/packages/server/core/src/core/StitchAppClient.ts
+++ b/packages/server/core/src/core/StitchAppClient.ts
@@ -20,20 +20,34 @@ import StitchServiceClient from "../services/StitchServiceClient"
 import StitchAuth from "./auth/StitchAuth";
 
 /**
- * The fundamental set of methods for communicating with a MongoDB Stitch 
- * application. Contains methods for executing Stitch functions and retrieving 
- * clients for Stitch services, and contains a `StitchAuth` object to manage 
- * the authentication state of the client. An implementation can be 
- * instantiated using the `Stitch` utility class.
+ * The StitchAppClient is the interface to a MongoDB Stitch App backend.
+ *
+ * It is created by the [[Stitch]] singleton.
+ *
+ * The StitchAppClient holds a [[StitchAuth]] object for managing the login state of the client.
+ *
+ * It provides clients for [Stitch Services](https://docs.mongodb.com/stitch/services/) including
+ * the [[RemoteMongoClient]] for database and collection access.
+ *
+ * Finally, the StitchAppClient can execute [Stitch Functions](https://docs.mongodb.com/stitch/functions/).
+ *
+ * ### Example
+ * ```
+ * import { Stitch } from "mongodb-stitch-server-sdk"
+ * 
+ * const client = Stitch.initializeDefaultAppClient('example-stitch-app-id')
+ * ```
+ * 
+ * ### See also
+ * - [[Stitch]]
+ * - [[StitchAuth]]
+ * - [[RemoteMongoClient]]
+ * - [Stitch Functions](https://docs.mongodb.com/stitch/functions/)
  */
 export default interface StitchAppClient {
   /**
    * The {@link StitchAuth} object representing the authentication state of 
    * this client. Includes methods for logging in and logging out.
-   *
-   * Authentication state can be persisted beyond the lifetime of a browser 
-   * session. A StitchAppClient retrieved from the `Stitch` singleton may or 
-   * may not be already authenticated when first initialized.
    */
   auth: StitchAuth;
 

--- a/packages/server/core/src/core/auth/StitchAuth.ts
+++ b/packages/server/core/src/core/auth/StitchAuth.ts
@@ -21,25 +21,41 @@ import StitchAuthListener from "./StitchAuthListener";
 import StitchUser from "./StitchUser";
 
 /**
- * A set of methods for retrieving or modifying the authentication state of a 
- * {@link StitchAppClient}. An implementation can be instantiated with a 
- * {@link StitchAppClient} instance.
+ * StitchAuth represents and controls the login state of a [[StitchAppClient]]. 
+ *
+ * Login is required for most Stitch functionality. Check which
+ * [Authentication Provider](https://docs.mongodb.com/stitch/authentication/)
+ * you are using and use [[loginWithCredential]] to log in.
+ *
+ * Once logged in, [[StitchAuth.user]] is a [[StitchUser]] object that can be examined for 
+ * user profile and other information.
+ * 
+ * To log out, use [[logout]].
+ *
+ * ### Examples
+ *
+ * For an example of [[loginWithCredential]], see [Anonymous Authentication](https://docs.mongodb.com/stitch/authentication/anonymous/).
+ *
+ * ### See also
+ * - [Users](https://docs.mongodb.com/stitch/users/)
+ * - [Authentication](https://docs.mongodb.com/stitch/authentication/)
+ * - [[StitchAppClient]]
+ * - [[StitchUser]]
  */
 export default interface StitchAuth {
   /**
-   * Whether or not the client containing this `StitchAuth` object is currently 
-   * authenticated.
+   * Whether or not the [[StitchAppClient]] containing this StitchAuth object 
+   * is currently logged in.
    */
   isLoggedIn: boolean;
 
   /**
-   * A {@link StitchUser} object representing the user that the client is 
-   * currently authenticated as. `undefined` if the client is not currently 
-   * authenticated.
+   * A [[StitchUser]] object representing who the client is currently logged in as,
+   * or `undefined` if the client is not currently logged in.
    */
   user?: StitchUser;
 
-  /**
+  /** @hidden
    * Retrieves the authentication provider client for the authentication 
    * provider associated with the specified factory.
    * 
@@ -49,7 +65,7 @@ export default interface StitchAuth {
     factory: AuthProviderClientFactory<ClientT>
   ): ClientT;
 
-  /**
+  /** @hidden
    * Retrieves the authentication provider client for the authentication 
    * provider associated with the specified factory and auth provider name.
    * 
@@ -61,10 +77,14 @@ export default interface StitchAuth {
   ): T;
 
   /**
-   * Authenticates the client as a MongoDB Stitch user using the provided 
-   * {@link StitchCredential}.
+   * Logs in as a [[StitchUser]] using the provided [[StitchCredential]].
    * 
-   * @param credential The credential to use when logging in.
+   * For an example of the most simple form of authentication, see
+   * [Anonymous Authentication](https://docs.mongodb.com/stitch/authentication/anonymous/).
+   *
+   * For another example, see [Email/Password Authentication](https://docs.mongodb.com/stitch/authentication/userpass/).
+   *
+   * @param credential The [[StitchCredential]] to use when logging in.
    */
   loginWithCredential(credential: StitchCredential): Promise<StitchUser>;
 
@@ -75,7 +95,7 @@ export default interface StitchAuth {
   logout(): Promise<void>;
 
   /**
-   * Registers a {@link StitchAuthListener} with the client.
+   * Registers a [[StitchAuthListener]] with the client.
    * @param listener The listener to be triggered when an authentication event
    * occurs on this auth object.
    */

--- a/packages/server/core/src/core/auth/StitchUser.ts
+++ b/packages/server/core/src/core/auth/StitchUser.ts
@@ -21,9 +21,14 @@ import {
   StitchUserIdentity } from "mongodb-stitch-core-sdk";
     
 /**
- * A user that a {@link StitchAppClient} is currently authenticated as.
- * Can be retrieved from a {@link StitchAuth} or from the result of certain 
- * methods.
+ * The StitchUser represents the currently logged-in user of the [[StitchAppClient]].
+ * 
+ * This can be retrieved from [[StitchAuth]] or from the result of certain methods
+ * such as [[StitchAuth.loginWithCredential]].
+ *
+ * ### See also
+ * - [[StitchAuth]]
+ * - [[StitchCredential]]
  */
 export default interface StitchUser extends CoreStitchUser {
   /**

--- a/packages/server/services/mongodb-remote/src/RemoteMongoClient.ts
+++ b/packages/server/services/mongodb-remote/src/RemoteMongoClient.ts
@@ -24,15 +24,38 @@ import RemoteMongoClientImpl from "./internal/RemoteMongoClientImpl";
 import RemoteMongoDatabase from "./RemoteMongoDatabase";
 
 /**
- * A client which can be used to get database and collection objects which can 
- * be used to interact with MongoDB data via the Stitch MongoDB service.
+ * The RemoteMongoClient can be used to get database and collection objects
+ * for interacting with MongoDB data via the Stitch MongoDB service.
+ *
+ * Service clients are created with [[StitchAppClient.getServiceClient]] by passing
+ * [[RemoteMongoClient.factory]] and the "Stitch Service Name" found under _Clusters_
+ * in the [Stitch control panel](https://stitch.mongodb.com)
+ * ("mongodb-atlas" by default).
+ *
+ * Once the RemoteMongoClient is instantiated, you can use the [[db]] method to access
+ * a [[RemoteMongoDatabase]]. A RemoteMongoDatabase will then provide access to
+ * a [[RemoteMongoCollection]], where you can read and write data.
+ *
+ * Note: The client needs to log in (at least anonymously) to use the database.
+ * See [[StitchAuth]].
+ * 
+ * ### Example
+ * ```
+ * const stitchClient = Stitch.initializeDefaultAppClient('your-stitch-app-id')
+ * const mongoClient = stitchClient.getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
+ * ```
+ *
+ *
+ * ### See also
+ * - [[StitchAppClient]]
+ * - [[RemoteMongoDatabase]]
  */
 export interface RemoteMongoClient {
   /**
-   * Gets a {@link RemoteMongoDatabase} instance for the given database name.
+   * Gets a [[RemoteMongoDatabase]] instance for the given database name.
    *
    * @param name the name of the database to retrieve
-   * @return a {@code RemoteMongoDatabase} representing the specified database
+   * @return a [[RemoteMongoDatabase]] representing the specified database
    */
   db(name: string): RemoteMongoDatabase;
 }

--- a/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -28,8 +28,59 @@ import {
 import RemoteMongoReadOperation from "./RemoteMongoReadOperation";
 
 /**
- * An interface representing a MongoDB collection accesible via the Stitch 
- * MongoDB service.
+ * The RemoteMongoCollection is the interface to a MongoDB database's
+ * collection via Stitch, allowing read and write.
+ *
+ * It is retrieved from a [[RemoteMongoDatabase]].
+ *
+ * The read operations are [[find]], [[count]] and [[aggregate]].
+ *
+ * The write operations are [[insertOne]], [[insertMany]], 
+ * [[updateOne]], [[updateMany]], [[deleteOne]], and [[deleteMany]].
+ *
+ * If you are already familiar with MongoDB drivers, it is important
+ * to understand that the RemoteMongoCollection only provides access
+ * to the operations available in Stitch. For a list of unsupported
+ * aggregation stages, see 
+ * [Unsupported Aggregation Stages](https://docs.mongodb.com/stitch/mongodb/actions/collection.aggregate/#unsupported-aggregation-stages).
+ *
+ * ### Example
+ *
+ * Here's how to access a database and one of its collections:
+ * ```
+ * // Assumption: Stitch client has been initialized and is already logged in.
+ * 
+ * // Get the existing Stitch client.
+ * const stitchClient = Stitch.defaultAppClient()
+ * 
+ * // Get a client of the Remote Mongo Service for database access
+ * const mongoClient = stitchClient.getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
+ *
+ * // Retrieve a database object
+ * const db = mongoClient.db('video')
+ *
+ * // Retrieve the collection in the database
+ * const movieDetails = db.collection('movieDetails')
+ *
+ * // Find 10 documents and log them to console.
+ * movieDetails.find({}, {limit: 10})
+ *   .toArray()
+ *   .then(results => console.log('Results:', results))
+ *   .catch(console.error)
+ * ```
+ *
+ * For more examples, see [CRUD Snippets](https://docs.mongodb.com/stitch/mongodb/crud-snippets/)
+ * on the MongoDB Stitch Documentation site.
+ *
+ * ### Note: Log in first
+ *
+ * A user will need to be logged in (at least anonymously) before you can read from
+ * or write to the collection. See [[StitchAuth]].
+ * 
+ * ### See also
+ * - [[RemoteMongoClient]]
+ * - [[RemoteMongoDatabase]]
+ * - [CRUD Snippets](https://docs.mongodb.com/stitch/mongodb/crud-snippets/)
  */
 export default interface RemoteMongoCollection<DocumentT> {
   /**
@@ -40,7 +91,7 @@ export default interface RemoteMongoCollection<DocumentT> {
   readonly namespace: string;
 
   /**
-   * Create a new emoteMongoCollection instance with a different default class to cast any
+   * Create a new RemoteMongoCollection instance with a different default class to cast any
    * documents returned from the database into.
    *
    * @param codec the default class to cast any documents returned from the database into.
@@ -60,7 +111,9 @@ export default interface RemoteMongoCollection<DocumentT> {
   count(query?: object, options?: RemoteCountOptions): Promise<number>;
 
   /**
-   * Finds all documents in the collection.
+   * Finds all documents in the collection that match the given query.
+   * 
+   * An empty query (`{}`) will match all documents.
    *
    * @param query the query filter
    * @return a read operation which can be used to execute the query
@@ -72,6 +125,10 @@ export default interface RemoteMongoCollection<DocumentT> {
 
   /**
    * Aggregates documents according to the specified aggregation pipeline.
+   *
+   * Stitch supports a subset of the available aggregation stages in MongoDB.
+   * See 
+   * [Unsupported Aggregation Stages](https://docs.mongodb.com/stitch/mongodb/actions/collection.aggregate/#unsupported-aggregation-stages).
    *
    * @param pipeline the aggregation pipeline
    * @return a read operation which can be used to execute the aggregation
@@ -96,9 +153,8 @@ export default interface RemoteMongoCollection<DocumentT> {
   insertMany(documents: DocumentT[]): Promise<RemoteInsertManyResult>;
 
   /**
-   * Removes at most one document from the collection that matches the given filter.  If no
-   * documents match, the collection is not
-   * modified.
+   * Removes at most one document from the collection that matches the given filter.
+   * If no documents match, the collection is not modified.
    *
    * @param query the query filter to apply the the delete operation
    * @return a Promise containing the result of the remove one operation

--- a/packages/server/services/mongodb-remote/src/RemoteMongoCursor.ts
+++ b/packages/server/services/mongodb-remote/src/RemoteMongoCursor.ts
@@ -15,9 +15,35 @@
  */
 
 /**
- * A cursor of documents which can be traversed asynchronously. A 
- * {@link RemoteMongoCursor} can be the result of a `find` or
- * `aggregate` operation on a {@link RemoteMongoReadOperation}.
+ * RemoteMongoCursor is an iterator over documents, which allows asynchronous traversal.
+ *
+ * A RemoteMongoCursor can be obtained from the result of a `find` or `aggregate` operation
+ * on a [[RemoteMongoCollection]] by calling [[RemoteMongoReadOperation.iterator]].
+ *
+ * ### Example
+ *
+ * This example shows how to iterate using a cursor and async/await.
+ * ```
+ * // Work with the movies collection
+ * const moviesCollection = db.collection('movieDetails')
+ *
+ * moviesCollection
+ *   .find({}, {limit: 100})
+ *   .iterator()
+ *   .then(async (cursor) => {
+ *     let movie = await cursor.next()
+ *     while (movie !== undefined) {
+ *       console.log(movie)
+ *       movie = await cursor.next()
+ *     }
+ *   })
+ * ```
+ * 
+ * ### See also
+ * - [[RemoteMongoCollection.find]]
+ * - [[RemoteMongoCollection.aggregate]]
+ * - [[RemoteMongoReadOperation]]
+ * - [[RemoteMongoReadOperation.iterator]]
  */
 export default class RemoteMongoCursor<T> {
   constructor(

--- a/packages/server/services/mongodb-remote/src/RemoteMongoDatabase.ts
+++ b/packages/server/services/mongodb-remote/src/RemoteMongoDatabase.ts
@@ -18,8 +18,34 @@ import { Codec } from "mongodb-stitch-core-sdk";
 import RemoteMongoCollection from "./RemoteMongoCollection";
 
 /**
- * An interface representing a MongoDB database accesible via the Stitch 
- * MongoDB service.
+ * RemoteMongoDatabase provides access to a MongoDB database.
+ * 
+ * It is instantiated by [[RemoteMongoClient]].
+ *
+ * Once instantiated, it can be used to access a [[RemoteMongoCollection]]
+ * for reading and writing data.
+ *
+ * ### Example
+ *
+ * Here's how to access a database and one of its collections:
+ * ```
+ * // Instantiate the Stitch client
+ * const stitchClient = Stitch.initializeDefaultAppClient('your-stitch-app-id')
+ *
+ * // Get a client of the Remote Mongo Service for database access
+ * const mongoClient = stitchClient.getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
+ *
+ * // Retrieve a database object
+ * const exampleDb = mongoClient.db('example-db')
+ * 
+ * // Retrieve the collection in the database
+ * const exampleCollection = db.collection('example-collection')
+ * ```
+ *
+ * ### See also
+ * - [[RemoteMongoClient]]
+ * - [[RemoteMongoCollection]]
+ * 
  */
 export default interface RemoteMongoDatabase {
   /**

--- a/packages/server/services/mongodb-remote/src/RemoteMongoReadOperation.ts
+++ b/packages/server/services/mongodb-remote/src/RemoteMongoReadOperation.ts
@@ -18,11 +18,38 @@ import { CoreRemoteMongoReadOperation } from "mongodb-stitch-core-services-mongo
 import RemoteMongoCursor from "./RemoteMongoCursor";
 
 /**
- * Represents a `find` or `aggregate` operation against a MongoDB collection. 
- * Use the methods in this class to execute the operation and retrieve the results.
+ * Represents a `find` or `aggregate` operation against a [[RemoteMongoCollection]].
+ * 
+ * The methods in this class execute the operation and retrieve the results,
+ * either as an [[iterator]] or all in one array with [[toArray]].
+ *
+ * ### Example
+ *
+ * This example finds 10 documents from the example collection. It assumes a user is
+ * already logged in -- see [[StitchAuth]] for more information on logging in.
+ * ```
+ * // Assumption: Stitch is already logged in
+ * 
+ * const exampleCollection = db.collection('example-collection')
+ * 
+ * exampleCollection
+ *   .find({}, { limit: 10 })   // find() returns a RemoteMongoReadOperation.
+ *   .toArray()                 // Read all results as an array.
+ *   .then(documents => console.log('Documents:', documents)) // If successful, log each document to console.
+ *   .catch(console.error)      // Otherwise, log any errors to the error console.
+ * ```
+ * 
+ * ### See also
+ * - [[RemoteMongoCollection]]
+ * - [[RemoteMongoCollection.find]]
+ * - [[RemoteMongoCollection.aggregate]]
+ * - [[RemoteFindOptions]]
+ * - [CRUD Snippets](https://docs.mongodb.com/stitch/mongodb/crud-snippets/#find)
  */
 export default class RemoteMongoReadOperation<T> {
+  /** @hidden */
   constructor(
+    /** @hidden */
     private readonly proxy: CoreRemoteMongoReadOperation<T>
   ) {}
 


### PR DESCRIPTION
- Copies the changes made previously to browser docs into the other
SDK docs.
- Net new content is effectively zero
- Attention paid to scrubbing references to RedirectCredential and
also Stitch's persistence across sessions.
- Remove references to collection 'watch' in RN and Server SDKs.

Staged changes:
https://docs-mongodbcom-staging.corp.mongodb.com/stitch/bush/docsp-4282-copy-docs/sdk/js-server/index.html

https://docs-mongodbcom-staging.corp.mongodb.com/stitch/bush/docsp-4282-copy-docs/sdk/react-native/index.html
