### PR TITLE
STITCH-2483 basic support for multi-user authentication

### DIFF
--- a/config/tsconfig.cjs.base.json
+++ b/config/tsconfig.cjs.base.json
@@ -3,6 +3,7 @@
         "target": "ES5",
         "module": "CommonJS",
         "moduleResolution": "Node",
+        "downlevelIteration": true,
         "sourceMap": true,
         "strictNullChecks": true,
         "declaration": true,

--- a/config/tsconfig.cjs.browser.base.json
+++ b/config/tsconfig.cjs.browser.base.json
@@ -3,6 +3,7 @@
         "target": "ES5",
         "module": "CommonJS",
         "moduleResolution": "Node",
+        "downlevelIteration": true,
         "sourceMap": true,
         "strictNullChecks": true,
         "declaration": true,

--- a/config/tsconfig.esm.base.json
+++ b/config/tsconfig.esm.base.json
@@ -3,6 +3,7 @@
         "target": "ES5",
         "module": "ES2015",
         "moduleResolution": "Node",
+        "downlevelIteration": true,
         "sourceMap": true,
         "strictNullChecks": true,
         "declaration": true,

--- a/config/tsconfig.esm.browser.base.json
+++ b/config/tsconfig.esm.browser.base.json
@@ -3,6 +3,7 @@
         "target": "ES5",
         "module": "ES2015",
         "moduleResolution": "Node",
+        "downlevelIteration": true,
         "sourceMap": true,
         "strictNullChecks": true,
         "declaration": true,

--- a/packages/browser/core/src/core/Stitch.ts
+++ b/packages/browser/core/src/core/Stitch.ts
@@ -24,7 +24,7 @@ import StitchAppClientImpl from "./internal/StitchAppClientImpl";
 import StitchAppClient from "./StitchAppClient";
 
 const DEFAULT_BASE_URL = "https://stitch.mongodb.com";
-const appClients: { [key: string]: StitchAppClientImpl } = {};
+let appClients: { [key: string]: StitchAppClientImpl } = {};
 
 /**
  * Singleton class with static utility functions for initializing a [[StitchAppClient]].
@@ -155,6 +155,15 @@ export default class Stitch {
     const client = new StitchAppClientImpl(clientAppId, builder.build());
     appClients[clientAppId] = client;
     return client;
+  }
+
+  /**
+   * This will clear out all initialized app clients. This method is mainly for
+   * debugging, simulating an application restart, as it will clear all clients
+   * stored in memory
+   */
+  public static clearApps() {
+    appClients = {};
   }
 
   private static localAppVersion: string;

--- a/packages/browser/core/src/core/auth/StitchAuth.ts
+++ b/packages/browser/core/src/core/auth/StitchAuth.ts
@@ -54,16 +54,34 @@ import StitchUser from "./StitchUser";
  */
 export default interface StitchAuth {
   /**
-   * Whether or not the [[StitchAppClient]] containing this StitchAuth object 
-   * is currently logged in.
+   * Whether or not there is a currently logged in active user of this 
+   * [[StitchAuth]]
    */
   isLoggedIn: boolean;
 
   /**
-   * A [[StitchUser]] object representing who the client is currently logged in as,
-   * or `undefined` if the client is not currently logged in.
+   * A [[StitchUser]] object representing the currently logged in, active user,
+   * or `undefined` if there is no logged in active user.
    */
   user?: StitchUser;
+
+  /**
+   * Returns a list of all users who have logged into this application, except
+   * those that have been removed manually, and anonymous users who have logged
+   * out.
+   */
+  listUsers(): Array<StitchUser>;
+
+  /**
+   * Switches the active user to the user with the specified id. The user must
+   * exist in the list of all users who have logged into this application, and
+   * the user must be currently logged in, otherwise this will throw a
+   * [[StitchClientError]].
+   * @param userId the id of the user to switch to
+   * @throws an exception if the user is not found, or the found user is not 
+   *         logged in
+   */
+  switchToUserWithId(userId: string): StitchUser
 
   /** @hidden
    * Retrieves the authentication provider client for the authentication 
@@ -131,10 +149,35 @@ export default interface StitchAuth {
   handleRedirectResult(): Promise<StitchUser>;
 
   /**
-   * Logs out the currently authenticated user, and clears any persisted 
-   * authentication information.
+   * Logs out the currently authenticated active user, and clears any persisted 
+   * authentication information for that user. There will be no active user 
+   * after this logout takes place, even if there are other logged in users.
+   * A user must be explicitly switched to, or a user must be logged in with
+   * a new credential.
    */
   logout(): Promise<void>;
+
+  /**
+   * Logs out the user with the provided id. The promise rejects with an 
+   * exception if the user was not found,
+   * @param userId the id of the user to log out
+   */
+  logoutUserWithId(userId: string): Promise<void>
+
+  /**
+   * Logs out the currently logged in, active user, and removes that user from
+   * the list of all users associated with this application.
+   */
+  removeUser(): Promise<void>
+
+  /**
+   * Removes the user with the provided id from the list of all users 
+   * associated with this application. If the user was logged in, the user will
+   * be logged out before being removed. The promise rejects with an exception 
+   * if the user was not found.
+   * @param userId the id of the user to remove
+   */
+  removeUserWithId(userId: string): Promise<void>
 
   /**
    * Registers a [[StitchAuthListener]] with the client.

--- a/packages/browser/core/src/core/auth/StitchAuthListener.ts
+++ b/packages/browser/core/src/core/auth/StitchAuthListener.ts
@@ -29,6 +29,7 @@ export default interface StitchAuthListener {
    * * When a user logs out.
    * * When a user is linked to another identity.
    * * When a listener is registered. This is to handle the case where during registration an event happens that the registerer would otherwise miss out on.
+   * * When the active user has been switched.
    *
    * @param auth The instance of StitchAuth where the event happened. It should be used to infer the current state of authentication.
    */

--- a/packages/browser/core/src/core/auth/StitchUser.ts
+++ b/packages/browser/core/src/core/auth/StitchUser.ts
@@ -50,6 +50,14 @@ export default interface StitchUser extends CoreStitchUser {
   readonly loggedInProviderName: string;
 
   /**
+   * Whether or not this user is logged in. If the user is logged in, it can be
+   * switched to without reauthenticating. NOTE: this is not a dynamic 
+   * property, this is the state of whether or not the user was logged in at 
+   * the time this user object was created.
+   */
+  readonly isLoggedIn: boolean;
+
+  /**
    * A string describing the type of this user. (Either `server` or `normal`)
    */
   readonly userType?: string;

--- a/packages/browser/core/src/core/auth/internal/StitchAuthImpl.ts
+++ b/packages/browser/core/src/core/auth/internal/StitchAuthImpl.ts
@@ -125,8 +125,6 @@ export default class StitchAuthImpl extends CoreStitchAuth<StitchUser>
     }
   }
 
-
-
   public loginWithCredential(
     credential: StitchCredential
   ): Promise<StitchUser> {

--- a/packages/browser/core/src/core/auth/internal/StitchAuthImpl.ts
+++ b/packages/browser/core/src/core/auth/internal/StitchAuthImpl.ts
@@ -125,6 +125,8 @@ export default class StitchAuthImpl extends CoreStitchAuth<StitchUser>
     }
   }
 
+
+
   public loginWithCredential(
     credential: StitchCredential
   ): Promise<StitchUser> {
@@ -226,7 +228,19 @@ export default class StitchAuthImpl extends CoreStitchAuth<StitchUser>
   }
 
   public logout(): Promise<void> {
-    return Promise.resolve(super.logoutInternal());
+    return super.logoutInternal();
+  }
+
+  public logoutUserWithId(userId: string): Promise<void> {
+    return super.logoutUserWithIdInternal(userId);
+  }
+
+  public removeUser(): Promise<void> {
+    return super.removeUserInternal();
+  }
+
+  public removeUserWithId(userId: string): Promise<void> {
+    return super.removeUserWithIdInternal(userId);
   }
 
   protected get deviceInfo() {

--- a/packages/browser/core/src/core/auth/internal/StitchUserFactoryImpl.ts
+++ b/packages/browser/core/src/core/auth/internal/StitchUserFactoryImpl.ts
@@ -35,12 +35,14 @@ export default class StitchUserFactoryImpl
     id: string,
     loggedInProviderType: string,
     loggedInProviderName: string,
+    isLoggedIn: boolean,
     userProfile: StitchUserProfileImpl
   ): StitchUser {
     return new StitchUserImpl(
       id,
       loggedInProviderType,
       loggedInProviderName,
+      isLoggedIn,
       userProfile,
       this.auth
     );

--- a/packages/browser/core/src/core/auth/internal/StitchUserImpl.ts
+++ b/packages/browser/core/src/core/auth/internal/StitchUserImpl.ts
@@ -30,10 +30,11 @@ export default class StitchUserImpl extends CoreStitchUserImpl
     id: string,
     loggedInProviderType: string,
     loggedInProviderName: string,
+    isLoggedIn: boolean,
     profile: StitchUserProfileImpl,
     private readonly auth: StitchAuthImpl
   ) {
-    super(id, loggedInProviderType, loggedInProviderName, profile);
+    super(id, loggedInProviderType, loggedInProviderName, isLoggedIn, profile);
   }
 
   public linkWithCredential(credential: StitchCredential): Promise<StitchUser> {

--- a/packages/browser/coretest/__tests__/StitchAppClientIntTests.ts
+++ b/packages/browser/coretest/__tests__/StitchAppClientIntTests.ts
@@ -171,6 +171,7 @@ describe("StitchAppClient", () => {
 
     expect(client.auth.listUsers().length).toEqual(3);
     
+    // verify ordering
     expect(client.auth.listUsers()[0].id).toEqual(anonUser.id);
     expect(client.auth.listUsers()[1].id).toEqual(emailUserId);
     expect(client.auth.listUsers()[2].id).toEqual(id2);
@@ -188,6 +189,7 @@ describe("StitchAppClient", () => {
 
     expect(client.auth.listUsers().length).toEqual(3);
     
+    // verify ordering is preserved
     expect(client.auth.listUsers()[0].id).toEqual(anonUser.id);
     expect(client.auth.listUsers()[1].id).toEqual(emailUserId);
     expect(client.auth.listUsers()[2].id).toEqual(id2);

--- a/packages/browser/coretest/__tests__/StitchAppClientIntTests.ts
+++ b/packages/browser/coretest/__tests__/StitchAppClientIntTests.ts
@@ -159,6 +159,7 @@ describe("StitchAppClient", () => {
     await client.auth.logout();
     expect(client.auth.isLoggedIn).toBeFalsy();
     expect(client.auth.user).not.toBeDefined();
+    expect(client.auth.listUsers()[2].isLoggedIn).toEqual(false);
 
     // Log back into the last user
     await client.auth.loginWithCredential(new UserPasswordCredential(
@@ -197,6 +198,7 @@ describe("StitchAppClient", () => {
     // verify that removing the user with id2 removes the second email/pass user
     // and logs out the active user
     await client.auth.logoutUserWithId(id2);
+    expect(client.auth.listUsers()[2].isLoggedIn).toEqual(false);
     expect(client.auth.isLoggedIn).toBeFalsy();
 
     // and assert that you can remove a user even if you're not logged in
@@ -297,6 +299,7 @@ describe("StitchAppClient", () => {
 
     await client.auth.logout();
     expect(client.auth.isLoggedIn).toBeFalsy();
+    expect(client.auth.listUsers()[0].isLoggedIn).toEqual(false);
 
     // assert that there is one user in the list, and that it did not get 
     // deleted when logging out because the linked user is no longer anon

--- a/packages/browser/testutils/src/BaseStitchBrowserIntTestHarness.ts
+++ b/packages/browser/testutils/src/BaseStitchBrowserIntTestHarness.ts
@@ -20,6 +20,7 @@ import {
   Stitch,
   StitchAppClient,
   StitchAppClientConfiguration,
+  Storage,
   UserPasswordAuthProviderClient,
   UserPasswordCredential
 } from "mongodb-stitch-browser-core";
@@ -50,7 +51,7 @@ export default class BaseStitchBrowserIntTestHarness extends BaseStitchIntTestHa
     return envVar !== undefined ? envVar : "http://localhost:9090";
   }
 
-  public getAppClient(app: AppResponse): StitchAppClient {
+  public getAppClient(app: AppResponse, storage?: Storage): StitchAppClient {
     if (Stitch.hasAppClient(app.clientAppId)) {
       return Stitch.getAppClient(app.clientAppId);
     }
@@ -59,7 +60,7 @@ export default class BaseStitchBrowserIntTestHarness extends BaseStitchIntTestHa
       app.clientAppId,
       new StitchAppClientConfiguration.Builder()
         .withBaseUrl(this.stitchBaseUrl)
-        .withStorage(new MemoryStorage(app.clientAppId))
+        .withStorage(storage || new MemoryStorage(app.clientAppId))
         .build()
     );
     this.clients.push(client);

--- a/packages/core/admin-client/src/StitchAdminUser.ts
+++ b/packages/core/admin-client/src/StitchAdminUser.ts
@@ -39,6 +39,13 @@ class StitchAdminUser implements CoreStitchUser {
   public readonly loggedInProviderName: string;
 
   /**
+   * Whether or not this user is logged in. NOTE: this is not a dynamic 
+   * property, this is the state of whether or not the user was logged in at 
+   * the time this user object was created.
+   */
+  public readonly isLoggedIn: boolean;
+
+  /**
    * A string describing the type of this user. (Either `server` or `normal`)
    */
   public get userType(): string {
@@ -65,11 +72,13 @@ class StitchAdminUser implements CoreStitchUser {
     id: string,
     providerType: string,
     providerName: string,
+    isLoggedIn: boolean,
     userProfile: StitchUserProfileImpl
   ) {
     this.id = id;
     this.loggedInProviderType = providerType;
     this.loggedInProviderName = providerName;
+    this.isLoggedIn = isLoggedIn;
     this.profile = userProfile;
   }
 }
@@ -83,12 +92,14 @@ class StitchAdminUserFactory implements StitchUserFactory<StitchAdminUser> {
     id: string,
     loggedInProviderType: string,
     loggedInProviderName: string,
+    isLoggedIn: boolean,
     userProfile?: StitchUserProfileImpl
   ): StitchAdminUser {
     return new StitchAdminUser(
       id,
       loggedInProviderType,
       loggedInProviderName,
+      isLoggedIn,
       userProfile!
     );
   }

--- a/packages/core/sdk/__tests__/ApiTestUtils.ts
+++ b/packages/core/sdk/__tests__/ApiTestUtils.ts
@@ -117,6 +117,19 @@ export const TEST_REFRESH_TOKEN: string = (() => {
   );
 })();
 
+function getTestLoginResponse(userId?: string): ApiAuthInfo {
+  return new class extends ApiAuthInfo {
+    constructor() {
+      super(
+        userId || "non-unique-user-id",
+        "0123456012345601234560123456",
+        TEST_ACCESS_TOKEN,
+        TEST_REFRESH_TOKEN
+      );
+    }
+  }();
+}
+
 /**
  * Gets a login response for testing that is always the same.
  */
@@ -197,6 +210,44 @@ export class RequestClassMatcher extends Matcher {
   }
 }
 
+let staticUniqueUserId = 0;
+export function getLastLoginUserId(): string {
+  return (staticUniqueUserId).toString();
+}
+
+export function mockNextUserResponse(
+  requestClientMock: StitchRequestClient,
+  userId?: string
+) {
+  if (userId === undefined) {
+    staticUniqueUserId++;
+  }
+
+  const idForResponse = userId || staticUniqueUserId.toString();
+
+  // Any /login works
+  when(
+    requestClientMock.doRequest(new RequestClassMatcher(
+      new RegExp(".*/login")
+    ) as any)
+  ).thenResolve({
+    body: JSON.stringify(getTestLoginResponse(idForResponse)),
+    headers: {},
+    statusCode: 200
+  });
+
+  // Any /session works
+  when(
+    requestClientMock.doRequest(new RequestClassMatcher(
+      new RegExp(".*/session")
+    ) as any)
+  ).thenResolve({
+    body: JSON.stringify(getTestLoginResponse(idForResponse)),
+    headers: {},
+    statusCode: 200
+  });
+}
+
 /**
  * Gets a mocked request client for testing that can be extended. In general
  * it supports enough to return responses for login, profile, and link. Anything else
@@ -211,7 +262,7 @@ export function getMockedRequestClient(): StitchRequestClient {
       new RegExp(".*/login")
     ) as any)
   ).thenResolve({
-    body: JSON.stringify(TEST_LOGIN_RESPONSE),
+    body: JSON.stringify(getTestLoginResponse(getLastLoginUserId())),
     headers: {},
     statusCode: 200
   });
@@ -222,7 +273,7 @@ export function getMockedRequestClient(): StitchRequestClient {
       new RegExp(".*/session")
     ) as any)
   ).thenResolve({
-    body: JSON.stringify(TEST_LOGIN_RESPONSE),
+    body: JSON.stringify(getTestLoginResponse(getLastLoginUserId())),
     headers: {},
     statusCode: 200
   });

--- a/packages/core/sdk/__tests__/auth/internal/CoreStitchAuthUnitTests.ts
+++ b/packages/core/sdk/__tests__/auth/internal/CoreStitchAuthUnitTests.ts
@@ -459,7 +459,7 @@ describe("CoreStitchAuthUnitTests", () => {
       expect(e).toBeInstanceOf(StitchClientError);
       const sce = e as StitchClientError;
       expect(sce.errorCode).toEqual(
-        StitchClientErrorCode.CouldNotFindUser
+        StitchClientErrorCode.UserNotFound
       );
     }
 
@@ -498,7 +498,7 @@ describe("CoreStitchAuthUnitTests", () => {
       expect(e).toBeInstanceOf(StitchClientError);
       const sce = e as StitchClientError;
       expect(sce.errorCode).toEqual(
-        StitchClientErrorCode.CannotSwitchToLoggedOutUser
+        StitchClientErrorCode.UserNotLoggedIn
       );
     }
   });

--- a/packages/core/sdk/__tests__/auth/internal/CoreStitchAuthUnitTests.ts
+++ b/packages/core/sdk/__tests__/auth/internal/CoreStitchAuthUnitTests.ts
@@ -264,6 +264,17 @@ describe("CoreStitchAuthUnitTests", () => {
       storage
     );
 
+    try {
+      await auth.logoutUserWithIdInternal("not_a_user_id");
+      fail("expected to fail because user does not exist");
+    } catch (e) {
+      expect(e).toBeInstanceOf(StitchClientError);
+      const sce = e as StitchClientError;
+      expect(sce.errorCode).toEqual(
+        StitchClientErrorCode.UserNotFound
+      );
+    }
+
     expect(auth.isLoggedIn).toBeFalsy();
     mockNextUserResponse(requestClientMock);
     const user1 = await auth.loginWithCredentialInternal(

--- a/packages/core/sdk/__tests__/auth/internal/models/AuthInfoUnitTests.ts
+++ b/packages/core/sdk/__tests__/auth/internal/models/AuthInfoUnitTests.ts
@@ -65,7 +65,27 @@ describe("AuthInfo", () => {
     expect(authInfo.userProfile).toEqual(undefined);
   });
 
-  it("must have deviceId, but nothing else if logged out", () => {
+  it("must have deviceId, but nothing else if user cleared", () => {
+    const authInfo = new AuthInfo(
+      userId,
+      deviceId,
+      accessToken,
+      refreshToken,
+      loggedInProviderType,
+      loggedInProviderName,
+      userProfile
+    ).withClearedUser();
+
+    expect(authInfo.userId).toEqual(undefined);
+    expect(authInfo.deviceId).toEqual(deviceId);
+    expect(authInfo.accessToken).toEqual(undefined);
+    expect(authInfo.refreshToken).toEqual(undefined);
+    expect(authInfo.loggedInProviderName).toEqual(undefined);
+    expect(authInfo.loggedInProviderType).toEqual(undefined);
+    expect(authInfo.userProfile).toEqual(undefined);
+  });
+
+  it("must have all fields except tokens when logged out", () => {
     const authInfo = new AuthInfo(
       userId,
       deviceId,
@@ -76,12 +96,12 @@ describe("AuthInfo", () => {
       userProfile
     ).loggedOut();
 
-    expect(authInfo.userId).toEqual(undefined);
+    expect(authInfo.userId).toEqual(userId);
     expect(authInfo.deviceId).toEqual(deviceId);
     expect(authInfo.accessToken).toEqual(undefined);
     expect(authInfo.refreshToken).toEqual(undefined);
-    expect(authInfo.loggedInProviderName).toEqual(undefined);
-    expect(authInfo.loggedInProviderType).toEqual(undefined);
-    expect(authInfo.userProfile).toEqual(undefined);
+    expect(authInfo.loggedInProviderName).toEqual(loggedInProviderName);
+    expect(authInfo.loggedInProviderType).toEqual(loggedInProviderType);
+    expect(authInfo.userProfile).toEqual(userProfile);
   });
 });

--- a/packages/core/sdk/src/StitchClientErrorCode.ts
+++ b/packages/core/sdk/src/StitchClientErrorCode.ts
@@ -22,10 +22,12 @@ export enum StitchClientErrorCode {
   LoggedOutDuringRequest,
   MustAuthenticateFirst,
   UserNoLongerValid,
+  CannotSwitchToLoggedOutUser,
+  CouldNotFindUser,
   CouldNotLoadPersistedAuthInfo,
   CouldNotPersistAuthInfo,
   StreamingNotSupported,
-  StreamClosed
+  StreamClosed,
 }
 
 /** @hidden */
@@ -36,6 +38,10 @@ export const clientErrorCodeDescs: { [key: number]: string } = {
     "method called requires being authenticated",
   [StitchClientErrorCode.UserNoLongerValid]:
     "user instance being accessed is no longer valid; please get a new user with auth.getUser()",
+  [StitchClientErrorCode.CannotSwitchToLoggedOutUser]:
+    "cannot make the active user a logged out user; please use loginWithCredential() to switch to this user",
+  [StitchClientErrorCode.CouldNotFindUser]:
+    "user not found in list of users",
   [StitchClientErrorCode.CouldNotLoadPersistedAuthInfo]:
     "failed to load stored auth information for Stitch",
   [StitchClientErrorCode.CouldNotPersistAuthInfo]:

--- a/packages/core/sdk/src/StitchClientErrorCode.ts
+++ b/packages/core/sdk/src/StitchClientErrorCode.ts
@@ -22,8 +22,8 @@ export enum StitchClientErrorCode {
   LoggedOutDuringRequest,
   MustAuthenticateFirst,
   UserNoLongerValid,
-  CannotSwitchToLoggedOutUser,
-  CouldNotFindUser,
+  UserNotFound,
+  UserNotLoggedIn,
   CouldNotLoadPersistedAuthInfo,
   CouldNotPersistAuthInfo,
   StreamingNotSupported,
@@ -38,10 +38,10 @@ export const clientErrorCodeDescs: { [key: number]: string } = {
     "method called requires being authenticated",
   [StitchClientErrorCode.UserNoLongerValid]:
     "user instance being accessed is no longer valid; please get a new user with auth.getUser()",
-  [StitchClientErrorCode.CannotSwitchToLoggedOutUser]:
-    "cannot make the active user a logged out user; please use loginWithCredential() to switch to this user",
-  [StitchClientErrorCode.CouldNotFindUser]:
+  [StitchClientErrorCode.UserNotFound]:
     "user not found in list of users",
+  [StitchClientErrorCode.UserNotLoggedIn]:
+    "cannot make the active user a logged out user; please use loginWithCredential() to switch to this user",
   [StitchClientErrorCode.CouldNotLoadPersistedAuthInfo]:
     "failed to load stored auth information for Stitch",
   [StitchClientErrorCode.CouldNotPersistAuthInfo]:

--- a/packages/core/sdk/src/auth/internal/AccessTokenRefresher.ts
+++ b/packages/core/sdk/src/auth/internal/AccessTokenRefresher.ts
@@ -59,6 +59,10 @@ export default class AccessTokenRefresher<T extends CoreStitchUser> {
       return false;
     }
 
+    if (!info.isLoggedIn) {
+      return false;
+    }
+
     let jwt: JWT;
     try {
       jwt = JWT.fromEncoded(info.accessToken!);

--- a/packages/core/sdk/src/auth/internal/AuthInfo.ts
+++ b/packages/core/sdk/src/auth/internal/AuthInfo.ts
@@ -34,10 +34,17 @@ export default class AuthInfo {
   }
 
   /** 
-   * An empty auth info is an auth info associated with no user.
+   * Whether or not this auth info is associated with a user.
+   */
+  public get hasUser(): boolean {
+    return this.userId === undefined;
+  }
+
+  /**
+   * An empty auth info is an auth info associated with no device ID.
    */
   public get isEmpty(): boolean {
-    return this.userId === undefined;
+    return this.deviceId === undefined;
   }
 
   /**
@@ -96,6 +103,18 @@ export default class AuthInfo {
       this.loggedInProviderType,
       this.loggedInProviderName,
       this.userProfile
+    );
+  }
+
+  public withClearedUser(): AuthInfo {
+    return new AuthInfo(
+      undefined,
+      this.deviceId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
     );
   }
 

--- a/packages/core/sdk/src/auth/internal/AuthInfo.ts
+++ b/packages/core/sdk/src/auth/internal/AuthInfo.ts
@@ -37,7 +37,7 @@ export default class AuthInfo {
    * Whether or not this auth info is associated with a user.
    */
   public get hasUser(): boolean {
-    return this.userId === undefined;
+    return this.userId !== undefined;
   }
 
   /**

--- a/packages/core/sdk/src/auth/internal/AuthInfo.ts
+++ b/packages/core/sdk/src/auth/internal/AuthInfo.ts
@@ -81,14 +81,30 @@ export default class AuthInfo {
 
   public loggedOut(): AuthInfo {
     return new AuthInfo(
-      undefined,
+      this.userId,
       this.deviceId,
       undefined,
       undefined,
-      undefined,
-      undefined,
-      undefined
+      this.loggedInProviderType,
+      this.loggedInProviderName,
+      this.userProfile
     );
+  }
+
+  public withAuthProvider(providerType: string, providerName: string) {
+    return new AuthInfo(
+      this.userId,
+      this.deviceId,
+      this.accessToken,
+      this.refreshToken,
+      providerType,
+      providerName,
+      this.userProfile
+    );
+  }
+
+  public get isLoggedIn(): boolean {
+    return this.accessToken !== undefined && this.refreshToken !== undefined;
   }
 
   /**

--- a/packages/core/sdk/src/auth/internal/AuthInfo.ts
+++ b/packages/core/sdk/src/auth/internal/AuthInfo.ts
@@ -32,6 +32,14 @@ export default class AuthInfo {
       undefined
     );
   }
+
+  /** 
+   * An empty auth info is an auth info associated with no user.
+   */
+  public get isEmpty(): boolean {
+    return this.userId === undefined;
+  }
+
   /**
    * The id of the Stitch user.
    */

--- a/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
+++ b/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
@@ -305,16 +305,16 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
    * The user being switched to is not guaranteed to be logged in.
    * 
    * @param userId The id of the user to switch to
-   * @throws [[StitchClientError.CouldNotFindUser]] if the user was not found
+   * @throws [[StitchClientError.UserNotFound]] if the user was not found
    */
   public switchToUserWithId(userId: string): TStitchUser {
     const authInfo = this.allUsersAuthInfo.get(userId);
     if (authInfo === undefined) {
-      throw new StitchClientError(StitchClientErrorCode.CouldNotFindUser);
+      throw new StitchClientError(StitchClientErrorCode.UserNotFound);
     }
     if (!authInfo.isLoggedIn) {
       throw new StitchClientError(
-        StitchClientErrorCode.CannotSwitchToLoggedOutUser
+        StitchClientErrorCode.UserNotLoggedIn
       );
     }
 
@@ -402,7 +402,7 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
     const authInfo = this.allUsersAuthInfo.get(userId);
     if (authInfo === undefined) {
       return Promise.reject(
-        new StitchClientError(StitchClientErrorCode.CouldNotFindUser)
+        new StitchClientError(StitchClientErrorCode.UserNotFound)
       );
     }
 
@@ -452,7 +452,7 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
 
     if (authInfo === undefined) {
       return Promise.reject(
-        new StitchClientError(StitchClientErrorCode.CouldNotFindUser)
+        new StitchClientError(StitchClientErrorCode.UserNotFound)
       );
     }
 
@@ -902,7 +902,7 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
   private clearUserAuth(userId: string) {
     const unclearedAuthInfo = this.allUsersAuthInfo.get(userId);
     if (unclearedAuthInfo === undefined) {
-      throw new StitchClientError(StitchClientErrorCode.CouldNotFindUser);
+      throw new StitchClientError(StitchClientErrorCode.UserNotFound);
     }
 
     try {

--- a/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
+++ b/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
@@ -349,10 +349,6 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
       return this.processLogin(credential, credential.authInfo, credential.asLink);
     }
 
-    if (!this.isLoggedIn) {
-      return this.doLogin(credential, false);
-    }
-
     // if we are logging in with a credential that reuses existing sessions
     // (e.g. the anonymous credential), check to see if any users are already
     // logged in with that credential.
@@ -411,7 +407,7 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
     }
 
     const clearAuthBlock = () => {
-      this.clearUserAuth(authInfo.userId!);
+      this.clearUserAuthTokens(authInfo.userId!);
 
       // if the user was anonymous, delete the user, since you can't log back
       // in to an anonymous user after they have logged out.
@@ -457,7 +453,7 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
     }
 
     const removeBlock = () => {
-      this.clearUserAuth(authInfo.userId!);
+      this.clearUserAuthTokens(authInfo.userId!);
       this.allUsersAuthInfo.delete(userId);
       writeAllUsersAuthInfoToStorage(this.allUsersAuthInfo, this.storage);
     }
@@ -886,7 +882,7 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
       return;
     }
 
-    this.clearUserAuth(this.activeUserAuthInfo.userId!);
+    this.clearUserAuthTokens(this.activeUserAuthInfo.userId!);
   }
 
   /**
@@ -899,7 +895,7 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
     }
   }
 
-  private clearUserAuth(userId: string) {
+  private clearUserAuthTokens(userId: string) {
     const unclearedAuthInfo = this.allUsersAuthInfo.get(userId);
     if (unclearedAuthInfo === undefined) {
       // this doesn't necessarily mean there's an error. we could be in a 

--- a/packages/core/sdk/src/auth/internal/CoreStitchUser.ts
+++ b/packages/core/sdk/src/auth/internal/CoreStitchUser.ts
@@ -50,7 +50,9 @@ export default interface CoreStitchUser {
 
   /**
    * Whether or not this user is logged in. If the user is logged in, it can be
-   * switched to without reauthenticating.
+   * switched to without reauthenticating. NOTE: this is not a dynamic 
+   * property, this is the state of whether or not the user was logged in at 
+   * the time this user object was created.
    */
   readonly isLoggedIn: boolean;
 }

--- a/packages/core/sdk/src/auth/internal/CoreStitchUser.ts
+++ b/packages/core/sdk/src/auth/internal/CoreStitchUser.ts
@@ -47,4 +47,10 @@ export default interface CoreStitchUser {
    * to this user which can be used to log in as this user.
    */
   readonly identities: StitchUserIdentity[];
+
+  /**
+   * Whether or not this user is logged in. If the user is logged in, it can be
+   * switched to without reauthenticating.
+   */
+  readonly isLoggedIn: boolean;
 }

--- a/packages/core/sdk/src/auth/internal/CoreStitchUserImpl.ts
+++ b/packages/core/sdk/src/auth/internal/CoreStitchUserImpl.ts
@@ -40,10 +40,13 @@ export default class CoreStitchUserImpl implements CoreStitchUser {
    */
   public readonly profile: StitchUserProfileImpl;
 
+  public readonly isLoggedIn: boolean;
+
   protected constructor(
     id: string,
     loggedInProviderType: string,
     loggedInProviderName: string,
+    isLoggedIn: boolean,
     profile?: StitchUserProfileImpl
   ) {
     this.id = id;
@@ -51,6 +54,7 @@ export default class CoreStitchUserImpl implements CoreStitchUser {
     this.loggedInProviderName = loggedInProviderName;
     this.profile =
       profile === undefined ? StitchUserProfileImpl.empty() : profile;
+    this.isLoggedIn = isLoggedIn;
   }
 
   /**

--- a/packages/core/sdk/src/auth/internal/StitchUserFactory.ts
+++ b/packages/core/sdk/src/auth/internal/StitchUserFactory.ts
@@ -30,6 +30,7 @@ interface StitchUserFactory<T extends CoreStitchUser> {
     id: string,
     loggedInProviderType: string,
     loggedInProviderName: string,
+    isLoggedIn: boolean,
     userProfile?: StitchUserProfileImpl
   ): T;
 }

--- a/packages/core/sdk/src/auth/internal/models/StoreAuthInfo.ts
+++ b/packages/core/sdk/src/auth/internal/models/StoreAuthInfo.ts
@@ -42,10 +42,10 @@ function readActiveUserFromStorage(storage: Storage): AuthInfo | undefined {
   return StoreAuthInfo.decode(JSON.parse(rawInfo));
 }
 
-function readCurrentUsersFromStorage(storage: Storage): { [key: string]: AuthInfo } {
+function readCurrentUsersFromStorage(storage: Storage): Map<string, AuthInfo> {
   const rawInfo = storage.get(StoreAuthInfo.ALL_USERS_STORAGE_NAME);
   if (!rawInfo) {
-    return {};
+    return new Map<string, AuthInfo>();
   }
 
   const rawArray = JSON.parse(rawInfo);
@@ -56,10 +56,10 @@ function readCurrentUsersFromStorage(storage: Storage): { [key: string]: AuthInf
     );
   }
 
-  const userIdToAuthInfoMap: { [key: string]: AuthInfo } = {}
+  const userIdToAuthInfoMap = new Map<string, AuthInfo>();
   rawArray.forEach(rawEntry => {
     const authInfo = StoreAuthInfo.decode(rawEntry);
-    userIdToAuthInfoMap[authInfo.userId!] = authInfo;
+    userIdToAuthInfoMap.set(authInfo.userId!, authInfo);
   })
 
   return userIdToAuthInfoMap;
@@ -96,15 +96,13 @@ function writeActiveUserAuthInfoToStorage(
 }
 
 function writeAllUsersAuthInfoToStorage(
-  currentUsersAuthInfo: { [key: string]: AuthInfo },
+  currentUsersAuthInfo: Map<string, AuthInfo>,
   storage: Storage
 ) {
   const encodedStoreInfos: any[] = []
-  for (const userId in currentUsersAuthInfo) {
-    const authInfo = currentUsersAuthInfo[userId];
-
+  for (var [userId, authInfo] of currentUsersAuthInfo) {
     const storeInfo = new StoreAuthInfo(
-      authInfo.userId!,
+      userId,
       authInfo.deviceId!,
       authInfo.accessToken!,
       authInfo.refreshToken!,

--- a/packages/core/sdk/src/auth/internal/models/StoreAuthInfo.ts
+++ b/packages/core/sdk/src/auth/internal/models/StoreAuthInfo.ts
@@ -131,7 +131,7 @@ function writeAllUsersAuthInfoToStorage(
 
 class StoreAuthInfo extends AuthInfo {
   public static readonly ACTIVE_USER_STORAGE_NAME: string = "auth_info";
-  public static readonly ALL_USERS_STORAGE_NAME
+  public static readonly ALL_USERS_STORAGE_NAME: string = "all_auth_infos";
 
   public static decode(from: any): StoreAuthInfo {
     const userId = from[Fields.USER_ID];

--- a/packages/react-native/core/src/core/Stitch.ts
+++ b/packages/react-native/core/src/core/Stitch.ts
@@ -24,7 +24,7 @@ import StitchAppClientImpl from "./internal/StitchAppClientImpl";
 import StitchAppClient from "./StitchAppClient";
 
 const DEFAULT_BASE_URL = "https://stitch.mongodb.com";
-const appClients: { [key: string]: StitchAppClientImpl } = {};
+let appClients: { [key: string]: StitchAppClientImpl } = {};
 
 /**
  * Singleton class with static utility functions for initializing the MongoDB 
@@ -152,6 +152,15 @@ export default class Stitch {
       appClients[clientAppId] = client;
       return Promise.resolve(client);
     }
+  }
+
+  /**
+   * This will clear out all initialized app clients. This method is mainly for
+   * debugging, simulating an application restart, as it will clear all clients
+   * stored in memory
+   */
+  public static clearApps() {
+    appClients = {};
   }
 
   private static localAppVersion: string;

--- a/packages/react-native/core/src/core/auth/StitchAuth.ts
+++ b/packages/react-native/core/src/core/auth/StitchAuth.ts
@@ -27,17 +27,34 @@ import StitchUser from "./StitchUser";
  */
 export default interface StitchAuth {
   /**
-   * Whether or not the client containing this `StitchAuth` object is currently 
-   * authenticated.
+   * Whether or not there is a currently logged in active user of this 
+   * [[StitchAuth]]
    */
   isLoggedIn: boolean;
 
   /**
-   * A {@link StitchUser} object representing the user that the client is 
-   * currently authenticated as. `undefined` if the client is not currently 
-   * authenticated.
+   * A [[StitchUser]] object representing the currently logged in, active user,
+   * or `undefined` if there is no logged in active user.
    */
   user?: StitchUser;
+
+  /**
+   * Returns a list of all users who have logged into this application, except
+   * those that have been removed manually, and anonymous users who have logged
+   * out.
+   */
+  listUsers(): Array<StitchUser>;
+
+  /**
+   * Switches the active user to the user with the specified id. The user must
+   * exist in the list of all users who have logged into this application, and
+   * the user must be currently logged in, otherwise this will throw a
+   * [[StitchClientError]].
+   * @param userId the id of the user to switch to
+   * @throws an exception if the user is not found, or the found user is not 
+   *         logged in
+   */
+  switchToUserWithId(userId: string): StitchUser
 
   /**
    * Retrieves the authentication provider client for the authentication 
@@ -69,10 +86,35 @@ export default interface StitchAuth {
   loginWithCredential(credential: StitchCredential): Promise<StitchUser>;
 
   /**
-   * Logs out the currently authenticated user, and clears any persisted 
-   * authentication information.
+   * Logs out the currently authenticated active user, and clears any persisted 
+   * authentication information for that user. There will be no active user 
+   * after this logout takes place, even if there are other logged in users.
+   * A user must be explicitly switched to, or a user must be logged in with
+   * a new credential.
    */
   logout(): Promise<void>;
+
+  /**
+   * Logs out the user with the provided id. The promise rejects with an 
+   * exception if the user was not found,
+   * @param userId the id of the user to log out
+   */
+  logoutUserWithId(userId: string): Promise<void>
+
+  /**
+   * Logs out the currently logged in, active user, and removes that user from
+   * the list of all users associated with this application.
+   */
+  removeUser(): Promise<void>
+
+  /**
+   * Removes the user with the provided id from the list of all users 
+   * associated with this application. If the user was logged in, the user will
+   * be logged out before being removed. The promise rejects with an exception 
+   * if the user was not found.
+   * @param userId the id of the user to remove
+   */
+  removeUserWithId(userId: string): Promise<void>
 
   /**
    * Registers a {@link StitchAuthListener} with the client.

--- a/packages/react-native/core/src/core/auth/StitchAuthListener.ts
+++ b/packages/react-native/core/src/core/auth/StitchAuthListener.ts
@@ -29,6 +29,7 @@ export default interface StitchAuthListener {
    * * When a user logs out.
    * * When a user is linked to another identity.
    * * When a listener is registered. This is to handle the case where during registration an event happens that the registerer would otherwise miss out on.
+   * * When the active user has been switched.
    *
    * @param auth The instance of StitchAuth where the event happened. It should be used to infer the current state of authentication.
    */

--- a/packages/react-native/core/src/core/auth/StitchUser.ts
+++ b/packages/react-native/core/src/core/auth/StitchUser.ts
@@ -47,6 +47,14 @@ export default interface StitchUser extends CoreStitchUser {
   readonly loggedInProviderName: string;
 
   /**
+   * Whether or not this user is logged in. If the user is logged in, it can be
+   * switched to without reauthenticating. NOTE: this is not a dynamic 
+   * property, this is the state of whether or not the user was logged in at 
+   * the time this user object was created.
+   */
+  readonly isLoggedIn: boolean;
+
+  /**
    * A string describing the type of this user. (Either `server` or `normal`)
    */
   readonly userType?: string;

--- a/packages/react-native/core/src/core/auth/internal/StitchAuthImpl.ts
+++ b/packages/react-native/core/src/core/auth/internal/StitchAuthImpl.ts
@@ -94,7 +94,19 @@ export default class StitchAuthImpl extends CoreStitchAuth<StitchUser>
   }
 
   public logout(): Promise<void> {
-    return Promise.resolve(super.logoutInternal());
+    return super.logoutInternal();
+  }
+
+  public logoutUserWithId(userId: string): Promise<void> {
+    return super.logoutUserWithIdInternal(userId);
+  }
+
+  public removeUser(): Promise<void> {
+    return super.removeUserInternal();
+  }
+
+  public removeUserWithId(userId: string): Promise<void> {
+    return super.removeUserWithIdInternal(userId);
   }
 
   protected get deviceInfo() {
@@ -109,7 +121,7 @@ export default class StitchAuthImpl extends CoreStitchAuth<StitchUser>
       info[DeviceFields.APP_VERSION] = this.appInfo.localAppVersion;
     }
 
-    info[DeviceFields.PLATFORM] = "js-server";
+    info[DeviceFields.PLATFORM] = "js-react-native";
     info[DeviceFields.PLATFORM_VERSION] = process.version;
     info[DeviceFields.SDK_VERSION] = version;
 

--- a/packages/react-native/core/src/core/auth/internal/StitchUserFactoryImpl.ts
+++ b/packages/react-native/core/src/core/auth/internal/StitchUserFactoryImpl.ts
@@ -35,12 +35,14 @@ export default class StitchUserFactoryImpl
     id: string,
     loggedInProviderType: string,
     loggedInProviderName: string,
+    isLoggedIn,
     userProfile: StitchUserProfileImpl
   ): StitchUser {
     return new StitchUserImpl(
       id,
       loggedInProviderType,
       loggedInProviderName,
+      isLoggedIn,
       userProfile,
       this.auth
     );

--- a/packages/react-native/core/src/core/auth/internal/StitchUserImpl.ts
+++ b/packages/react-native/core/src/core/auth/internal/StitchUserImpl.ts
@@ -29,10 +29,11 @@ export default class StitchUserImpl extends CoreStitchUserImpl
     id: string,
     loggedInProviderType: string,
     loggedInProviderName: string,
+    isLoggedIn: boolean,
     profile: StitchUserProfileImpl,
     private readonly auth: StitchAuthImpl
   ) {
-    super(id, loggedInProviderType, loggedInProviderName, profile);
+    super(id, loggedInProviderType, loggedInProviderName, isLoggedIn, profile);
   }
 
   public linkWithCredential(credential: StitchCredential): Promise<StitchUser> {

--- a/packages/react-native/core/src/index.ts
+++ b/packages/react-native/core/src/index.ts
@@ -61,6 +61,8 @@ import StitchAppClient from "./core/StitchAppClient";
 import NamedServiceClientFactory from "./services/internal/NamedServiceClientFactory";
 import StitchServiceClient from "./services/StitchServiceClient";
 
+import RNAsyncStorage from "./core/internal/common/RNAsyncStorage";
+
 export {
   BSON,
   AnonymousAuthProvider,
@@ -94,6 +96,7 @@ export {
   StitchUserIdentity,
   Storage,
   MemoryStorage,
+  RNAsyncStorage,
   Transport,
   UserType,
   NamedServiceClientFactory,

--- a/packages/react-native/coretest/__tests__/StitchAppClientIntTests.ts
+++ b/packages/react-native/coretest/__tests__/StitchAppClientIntTests.ts
@@ -161,6 +161,7 @@ describe("StitchAppClient", () => {
     await client.auth.logout();
     expect(client.auth.isLoggedIn).toBeFalsy();
     expect(client.auth.user).not.toBeDefined();
+    expect(client.auth.listUsers()[2].isLoggedIn).toEqual(false);
 
     // Log back into the last user
     await client.auth.loginWithCredential(new UserPasswordCredential(
@@ -198,6 +199,7 @@ describe("StitchAppClient", () => {
     // and logs out the active user
     await client.auth.logoutUserWithId(id2);
     expect(client.auth.isLoggedIn).toBeFalsy();
+    expect(client.auth.listUsers()[2].isLoggedIn).toEqual(false);
 
     // and assert that you can remove a user even if you're not logged in
     await client.auth.removeUserWithId(id2);
@@ -297,6 +299,7 @@ describe("StitchAppClient", () => {
 
     await client.auth.logout();
     expect(client.auth.isLoggedIn).toBeFalsy();
+    expect(client.auth.listUsers()[0].isLoggedIn).toEqual(false);
 
     // assert that there is one user in the list, and that it did not get 
     // deleted when logging out because the linked user is no longer anon

--- a/packages/react-native/coretest/__tests__/StitchAppClientIntTests.ts
+++ b/packages/react-native/coretest/__tests__/StitchAppClientIntTests.ts
@@ -154,6 +154,96 @@ describe("StitchAppClient", () => {
     await client.auth.logout();
     expect(client.auth.isLoggedIn).toBeFalsy();
     expect(client.auth.user).not.toBeDefined();
+
+    // Log back into the last user
+    await client.auth.loginWithCredential(new UserPasswordCredential(
+      "test2@10gen.com", "hunter2"
+    ));
+    expect(client.auth.isLoggedIn).toBeTruthy();
+    expect(client.auth.user!.loggedInProviderType).toEqual(
+      UserPasswordAuthProvider.TYPE
+    );
+
+    expect(client.auth.listUsers().length).toEqual(3);
+    
+    expect(client.auth.listUsers()[0].id).toEqual(anonUser.id);
+    expect(client.auth.listUsers()[1].id).toEqual(emailUserId);
+    expect(client.auth.listUsers()[2].id).toEqual(id2);
+
+    // imitate an app restart
+    Stitch.clearApps();
+    client = harness.getAppClient(appResponse as AppResponse, storage);
+
+    // check everything is as it was
+    expect(client.auth.listUsers().length).toEqual(3);
+    expect(client.auth.isLoggedIn).toBeTruthy();
+    expect(client.auth.user!.loggedInProviderType).toEqual(
+      UserPasswordAuthProvider.TYPE
+    );
+
+    expect(client.auth.listUsers().length).toEqual(3);
+    
+    expect(client.auth.listUsers()[0].id).toEqual(anonUser.id);
+    expect(client.auth.listUsers()[1].id).toEqual(emailUserId);
+    expect(client.auth.listUsers()[2].id).toEqual(id2);
+
+    // verify that removing the user with id2 removes the second email/pass user
+    // and logs out the active user
+    await client.auth.logoutUserWithId(id2);
+    expect(client.auth.isLoggedIn).toBeFalsy();
+
+    // and assert that you can remove a user even if you're not logged in
+    await client.auth.removeUserWithId(id2);
+    expect(client.auth.listUsers().length).toEqual(2);
+
+    // switch to the user with emailUserId and verify 
+    // that is the user switched to
+    client.auth.switchToUserWithId(emailUserId);
+    
+    expect(client.auth.isLoggedIn).toBeTruthy();
+    expect(client.auth.user!.loggedInProviderType).toEqual(
+      UserPasswordAuthProvider.TYPE
+    );
+    expect(client.auth.user!.id).toEqual(emailUserId);
+
+    expect(client.auth.listUsers()[0].id).toEqual(anonUser.id);
+    expect(client.auth.listUsers()[1].id).toEqual(emailUserId);
+
+    // imitate an app restart
+    Stitch.clearApps();
+    client = harness.getAppClient(appResponse as AppResponse, storage);
+
+    // assert that we're still logged in
+    expect(client.auth.listUsers().length).toEqual(2);
+    expect(client.auth.isLoggedIn).toBeTruthy();
+    expect(client.auth.user!.loggedInProviderType).toEqual(
+      UserPasswordAuthProvider.TYPE
+    );
+    expect(client.auth.user!.id).toEqual(emailUserId);
+
+    expect(client.auth.listUsers()[0].id).toEqual(anonUser.id);
+    expect(client.auth.listUsers()[1].id).toEqual(emailUserId);
+
+    // assert that removing the active user leaves just the anon user
+    await client.auth.removeUser();
+    expect(client.auth.isLoggedIn).toBeFalsy();
+    expect(client.auth.listUsers().length).toEqual(1);
+
+    client.auth.switchToUserWithId(anonUser.id);
+    expect(client.auth.isLoggedIn).toBeTruthy();
+
+    expect(client.auth.user!.loggedInProviderType).toEqual(
+      AnonymousAuthProvider.TYPE
+    );
+    expect(client.auth.user!.id).toEqual(anonUser.id);
+    expect(client.auth.listUsers()[0].id).toEqual(anonUser.id);
+
+    // assert that logging out of the anonymous user removes it as well
+    await client.auth.logout();
+
+    expect(client.auth.isLoggedIn).toBeFalsy();
+    expect(client.auth.listUsers().length).toEqual(0);
+    expect(client.auth.user).toBeUndefined();
   });
 
   it("should link identity", async () => {

--- a/packages/react-native/testutils/src/BaseStitchRNIntTestHarness.ts
+++ b/packages/react-native/testutils/src/BaseStitchRNIntTestHarness.ts
@@ -18,6 +18,7 @@ import { fail } from "assert";
 import { App, AppResponse } from "mongodb-stitch-core-admin-client";
 import { BaseStitchIntTestHarness } from "mongodb-stitch-core-testutils";
 import {
+  RNAsyncStorage,
   Stitch,
   StitchAppClient,
   StitchAppClientConfiguration,
@@ -51,7 +52,7 @@ export default class BaseStitchRNIntTestHarness extends BaseStitchIntTestHarness
     return envVar !== undefined ? envVar : "http://localhost:9090";
   }
 
-  public getAppClient(app: AppResponse): Promise<StitchAppClient> {
+  public getAppClient(app: AppResponse, storage?: Storage): Promise<StitchAppClient> {
     if (Stitch.hasAppClient(app.clientAppId)) {
       return Promise.resolve(Stitch.getAppClient(app.clientAppId));
     }
@@ -60,6 +61,7 @@ export default class BaseStitchRNIntTestHarness extends BaseStitchIntTestHarness
       app.clientAppId,
       new StitchAppClientConfiguration.Builder()
         .withBaseUrl(this.stitchBaseUrl)
+        .withStorage(storage || new RNAsyncStorage(app.clientAppId))
         .build()
     ).then(client => {
       this.clients.push(client);

--- a/packages/react-native/testutils/src/BaseStitchRNIntTestHarness.ts
+++ b/packages/react-native/testutils/src/BaseStitchRNIntTestHarness.ts
@@ -21,6 +21,7 @@ import {
   Stitch,
   StitchAppClient,
   StitchAppClientConfiguration,
+  Storage,
   UserPasswordAuthProviderClient,
   UserPasswordCredential
 } from "mongodb-stitch-react-native-core";

--- a/packages/server/core/src/core/Stitch.ts
+++ b/packages/server/core/src/core/Stitch.ts
@@ -28,7 +28,7 @@ import NodeFetchStreamTransport from "./internal/net/NodeFetchStreamTransport";
 
 const DEFAULT_BASE_URL = "https://stitch.mongodb.com";
 const DEFAULT_STITCH_DIR = ".stitch/apps";
-const appClients: { [key: string]: StitchAppClientImpl } = {};
+let appClients: { [key: string]: StitchAppClientImpl } = {};
 
 /**
  * Singleton class with static utility functions for initializing the MongoDB 
@@ -142,6 +142,15 @@ export default class Stitch {
     const client = new StitchAppClientImpl(clientAppId, builder.build());
     appClients[clientAppId] = client;
     return client;
+  }
+  
+  /**
+   * This will clear out all initialized app clients. This method is mainly for
+   * debugging, simulating an application restart, as it will clear all clients
+   * stored in memory
+   */
+  public static clearApps() {
+    appClients = {};
   }
 
   private static localAppVersion: string;

--- a/packages/server/core/src/core/auth/StitchAuth.ts
+++ b/packages/server/core/src/core/auth/StitchAuth.ts
@@ -27,17 +27,34 @@ import StitchUser from "./StitchUser";
  */
 export default interface StitchAuth {
   /**
-   * Whether or not the client containing this `StitchAuth` object is currently 
-   * authenticated.
+   * Whether or not there is a currently logged in active user of this 
+   * [[StitchAuth]]
    */
   isLoggedIn: boolean;
 
   /**
-   * A {@link StitchUser} object representing the user that the client is 
-   * currently authenticated as. `undefined` if the client is not currently 
-   * authenticated.
+   * A [[StitchUser]] object representing the currently logged in, active user,
+   * or `undefined` if there is no logged in active user.
    */
   user?: StitchUser;
+
+  /**
+   * Returns a list of all users who have logged into this application, except
+   * those that have been removed manually, and anonymous users who have logged
+   * out.
+   */
+  listUsers(): Array<StitchUser>;
+
+  /**
+   * Switches the active user to the user with the specified id. The user must
+   * exist in the list of all users who have logged into this application, and
+   * the user must be currently logged in, otherwise this will throw a
+   * [[StitchClientError]].
+   * @param userId the id of the user to switch to
+   * @throws an exception if the user is not found, or the found user is not 
+   *         logged in
+   */
+  switchToUserWithId(userId: string): StitchUser
 
   /**
    * Retrieves the authentication provider client for the authentication 
@@ -69,10 +86,35 @@ export default interface StitchAuth {
   loginWithCredential(credential: StitchCredential): Promise<StitchUser>;
 
   /**
-   * Logs out the currently authenticated user, and clears any persisted 
-   * authentication information.
+   * Logs out the currently authenticated active user, and clears any persisted 
+   * authentication information for that user. There will be no active user 
+   * after this logout takes place, even if there are other logged in users.
+   * A user must be explicitly switched to, or a user must be logged in with
+   * a new credential.
    */
   logout(): Promise<void>;
+
+  /**
+   * Logs out the user with the provided id. The promise rejects with an 
+   * exception if the user was not found,
+   * @param userId the id of the user to log out
+   */
+  logoutUserWithId(userId: string): Promise<void>
+
+  /**
+   * Logs out the currently logged in, active user, and removes that user from
+   * the list of all users associated with this application.
+   */
+  removeUser(): Promise<void>
+
+  /**
+   * Removes the user with the provided id from the list of all users 
+   * associated with this application. If the user was logged in, the user will
+   * be logged out before being removed. The promise rejects with an exception 
+   * if the user was not found.
+   * @param userId the id of the user to remove
+   */
+  removeUserWithId(userId: string): Promise<void>
 
   /**
    * Registers a {@link StitchAuthListener} with the client.

--- a/packages/server/core/src/core/auth/StitchAuthListener.ts
+++ b/packages/server/core/src/core/auth/StitchAuthListener.ts
@@ -29,6 +29,7 @@ export default interface StitchAuthListener {
    * * When a user logs out.
    * * When a user is linked to another identity.
    * * When a listener is registered. This is to handle the case where during registration an event happens that the registerer would otherwise miss out on.
+   * * When the active user has been switched.
    *
    * @param auth The instance of StitchAuth where the event happened. It should be used to infer the current state of authentication.
    */

--- a/packages/server/core/src/core/auth/StitchUser.ts
+++ b/packages/server/core/src/core/auth/StitchUser.ts
@@ -47,6 +47,14 @@ export default interface StitchUser extends CoreStitchUser {
   readonly loggedInProviderName: string;
 
   /**
+   * Whether or not this user is logged in. If the user is logged in, it can be
+   * switched to without reauthenticating. NOTE: this is not a dynamic 
+   * property, this is the state of whether or not the user was logged in at 
+   * the time this user object was created.
+   */
+  readonly isLoggedIn: boolean;
+
+  /**
    * A string describing the type of this user. (Either `server` or `normal`)
    */
   readonly userType?: string;

--- a/packages/server/core/src/core/auth/internal/StitchAuthImpl.ts
+++ b/packages/server/core/src/core/auth/internal/StitchAuthImpl.ts
@@ -94,7 +94,19 @@ export default class StitchAuthImpl extends CoreStitchAuth<StitchUser>
   }
 
   public logout(): Promise<void> {
-    return Promise.resolve(super.logoutInternal());
+    return super.logoutInternal();
+  }
+
+  public logoutUserWithId(userId: string): Promise<void> {
+    return super.logoutUserWithIdInternal(userId);
+  }
+
+  public removeUser(): Promise<void> {
+    return super.removeUserInternal();
+  }
+
+  public removeUserWithId(userId: string): Promise<void> {
+    return super.removeUserWithIdInternal(userId);
   }
 
   protected get deviceInfo() {

--- a/packages/server/core/src/core/auth/internal/StitchUserFactoryImpl.ts
+++ b/packages/server/core/src/core/auth/internal/StitchUserFactoryImpl.ts
@@ -35,12 +35,14 @@ export default class StitchUserFactoryImpl
     id: string,
     loggedInProviderType: string,
     loggedInProviderName: string,
+    isLoggedIn: boolean,
     userProfile: StitchUserProfileImpl
   ): StitchUser {
     return new StitchUserImpl(
       id,
       loggedInProviderType,
       loggedInProviderName,
+      isLoggedIn,
       userProfile,
       this.auth
     );

--- a/packages/server/core/src/core/auth/internal/StitchUserImpl.ts
+++ b/packages/server/core/src/core/auth/internal/StitchUserImpl.ts
@@ -29,10 +29,11 @@ export default class StitchUserImpl extends CoreStitchUserImpl
     id: string,
     loggedInProviderType: string,
     loggedInProviderName: string,
+    isLoggedIn: boolean,
     profile: StitchUserProfileImpl,
     private readonly auth: StitchAuthImpl
   ) {
-    super(id, loggedInProviderType, loggedInProviderName, profile);
+    super(id, loggedInProviderType, loggedInProviderName, isLoggedIn, profile);
   }
 
   public linkWithCredential(credential: StitchCredential): Promise<StitchUser> {

--- a/packages/server/coretest/__tests__/StitchAppClientIntTests.ts
+++ b/packages/server/coretest/__tests__/StitchAppClientIntTests.ts
@@ -159,6 +159,7 @@ describe("StitchAppClient", () => {
     await client.auth.logout();
     expect(client.auth.isLoggedIn).toBeFalsy();
     expect(client.auth.user).not.toBeDefined();
+    expect(client.auth.listUsers()[2].isLoggedIn).toEqual(false);
 
     // Log back into the last user
     await client.auth.loginWithCredential(new UserPasswordCredential(
@@ -195,6 +196,7 @@ describe("StitchAppClient", () => {
     // verify that removing the user with id2 removes the second email/pass user
     // and logs out the active user
     await client.auth.logoutUserWithId(id2);
+    expect(client.auth.listUsers()[2].isLoggedIn).toEqual(false);
     expect(client.auth.isLoggedIn).toBeFalsy();
 
     // and assert that you can remove a user even if you're not logged in
@@ -295,6 +297,7 @@ describe("StitchAppClient", () => {
 
     await client.auth.logout();
     expect(client.auth.isLoggedIn).toBeFalsy();
+    expect(client.auth.listUsers()[0].isLoggedIn).toEqual(false);
 
     // assert that there is one user in the list, and that it did not get 
     // deleted when logging out because the linked user is no longer anon

--- a/packages/server/testutils/src/BaseStitchServerIntTestHarness.ts
+++ b/packages/server/testutils/src/BaseStitchServerIntTestHarness.ts
@@ -22,6 +22,7 @@ import {
   Stitch,
   StitchAppClient,
   StitchAppClientConfiguration,
+  Storage,
   UserPasswordAuthProviderClient,
   UserPasswordCredential
 } from "mongodb-stitch-server-core";
@@ -50,7 +51,7 @@ export default class BaseStitchServerIntTestHarness extends BaseStitchIntTestHar
     return envVar !== undefined ? envVar : "http://localhost:9090";
   }
 
-  public getAppClient(app: AppResponse): StitchAppClient {
+  public getAppClient(app: AppResponse, storage?: Storage): StitchAppClient {
     if (Stitch.hasAppClient(app.clientAppId)) {
       return Stitch.getAppClient(app.clientAppId);
     }
@@ -59,7 +60,7 @@ export default class BaseStitchServerIntTestHarness extends BaseStitchIntTestHar
       app.clientAppId,
       new StitchAppClientConfiguration.Builder()
         .withBaseUrl(this.stitchBaseUrl)
-        .withStorage(new MemoryStorage(app.clientAppId))
+        .withStorage(storage || new MemoryStorage(app.clientAppId))
         .build()
     );
     this.clients.push(client);


### PR DESCRIPTION
This should cover STITCH-2483 and STITCH-2484.

I excluded `lastAuthActivity` because this PR was getting big and I wanted to get something up. I can do `lastAuthActivity` in a separate PR after this one is merged, as it is quite independent from the rest of this work.

This should cover everything in the new spec doc Tyler wrote, as well as preserving device ID when not logged in, which is something I'll add to the spec.