### PR TITLE
Add findOne() functionality

### DIFF
--- a/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -206,7 +206,7 @@ describe("RemoteMongoClient", () => {
     const coll = getTestColl();
 
     let result = await coll.findOne();
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
 
     const doc1 = { hello: "world" };
     await coll.insertOne(doc1);
@@ -228,7 +228,7 @@ describe("RemoteMongoClient", () => {
     expect(withoutId(result)).toEqual(withoutId(doc2));
 
     result = await coll.findOne({notARealField: "bogus"});
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
 
     result = await coll.findOne({}, {sort: {_id: 1}})
     expect(result).toBeDefined();

--- a/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -202,6 +202,55 @@ describe("RemoteMongoClient", () => {
     }
   });
 
+  it("should find one", async () => {
+    const coll = getTestColl();
+
+    let result = await coll.findOne();
+    expect(result).toBeNull();
+
+    const doc1 = { hello: "world" };
+    await coll.insertOne(doc1);
+
+    result = await coll.findOne();
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc1));
+
+    
+    const doc2 = { hello: "world2", other: "other" };
+    await coll.insertOne(doc2);
+
+    result = await coll.findOne({hello: "world"});
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc1));
+
+    result = await coll.findOne({other: "other"})
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc2));
+
+    result = await coll.findOne({notARealField: "bogus"});
+    expect(result).toBeNull();
+
+    result = await coll.findOne({}, {sort: {_id: 1}})
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc1));
+
+    result = await coll.findOne({}, {sort: {_id: -1}})
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc2));
+
+    result = await coll.findOne(doc2, {projection: {_id: 0}});
+    expect(result).toBeDefined();
+    expect(result).toEqual(withoutId(doc2));
+
+    try {
+      await coll.find({ $who: 1 }).first();
+      fail();
+    } catch (error) {
+      expect(error instanceof StitchServiceError).toBeTruthy();
+      expect(StitchServiceErrorCode.MongoDBError).toEqual(error.errorCode);
+    }
+  });
+
   it("should aggregate", async () => {
     const coll = getTestColl();
     let iter = coll.aggregate([]);

--- a/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -206,7 +206,7 @@ describe("RemoteMongoClient", () => {
     const coll = getTestColl();
 
     let result = await coll.findOne();
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
 
     const doc1 = { hello: "world" };
     await coll.insertOne(doc1);
@@ -228,7 +228,7 @@ describe("RemoteMongoClient", () => {
     expect(withoutId(result)).toEqual(withoutId(doc2));
 
     result = await coll.findOne({notARealField: "bogus"});
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
 
     result = await coll.findOne({}, {sort: {_id: 1}})
     expect(result).toBeDefined();

--- a/packages/browser/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/browser/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -104,12 +104,12 @@ export default interface RemoteMongoCollection<DocumentT> {
    * An empty query (`{}`) will match all documents.
    *
    * @param query the query filter
-   * @return the resulting document or undefined if the query resulted in zero matches
+   * @return the resulting document or null if the query resulted in zero matches
    */
   findOne(
     query?: object,
     options?: RemoteFindOptions
-  ): Promise<DocumentT | undefined>;
+  ): Promise<DocumentT | null>;
 
   /**
    * Aggregates documents according to the specified aggregation pipeline.

--- a/packages/browser/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/browser/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -99,6 +99,19 @@ export default interface RemoteMongoCollection<DocumentT> {
   ): RemoteMongoReadOperation<DocumentT>;
 
   /**
+   * Finds one document in the collection that matches the given query.
+   * 
+   * An empty query (`{}`) will match all documents.
+   *
+   * @param query the query filter
+   * @return the resulting document or undefined if the query resulted in zero matches
+   */
+  findOne(
+    query?: object,
+    options?: RemoteFindOptions
+  ): Promise<DocumentT | undefined>;
+
+  /**
    * Aggregates documents according to the specified aggregation pipeline.
    *
    * Stitch supports a subset of the available aggregation stages in MongoDB.

--- a/packages/browser/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/browser/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -83,6 +83,19 @@ export default class RemoteMongoCollectionImpl<DocumentT> {
   }
 
   /**
+   * Finds one document in the collection.
+   *
+   * @param query the query filter
+   * @return the resulting document or undefined if the query resulted in zero matches
+   */
+  public findOne(
+    query?: object,
+    options?: RemoteFindOptions
+  ): Promise<DocumentT | undefined> {
+    return this.proxy.findOne(query, options);
+  }
+
+  /**
    * Aggregates documents according to the specified aggregation pipeline.
    *
    * @param pipeline the aggregation pipeline

--- a/packages/browser/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/browser/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -86,12 +86,12 @@ export default class RemoteMongoCollectionImpl<DocumentT> {
    * Finds one document in the collection.
    *
    * @param query the query filter
-   * @return the resulting document or undefined if the query resulted in zero matches
+   * @return the resulting document or null if the query resulted in zero matches
    */
   public findOne(
     query?: object,
     options?: RemoteFindOptions
-  ): Promise<DocumentT | undefined> {
+  ): Promise<DocumentT | null> {
     return this.proxy.findOne(query, options);
   }
 

--- a/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
+++ b/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
@@ -211,6 +211,10 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
   ): Promise<T> {
     return this.doAuthenticatedRequest(stitchReq)
       .then(response => {
+        if (response.body! === '{"$undefined":true}') {
+          return undefined;
+        }
+       
         const obj = EJSON.parse(response.body!, { strict: false });
 
         if (decoder) {

--- a/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
+++ b/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
@@ -210,11 +210,7 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
     decoder?: Decoder<T>
   ): Promise<T> {
     return this.doAuthenticatedRequest(stitchReq)
-      .then(response => {
-        if (response.body! === '{"$undefined":true}') {
-          return undefined;
-        }
-       
+      .then(response => {       
         const obj = EJSON.parse(response.body!, { strict: false });
 
         if (decoder) {

--- a/packages/core/services/mongodb-remote/__tests__/CoreRemoteMongoCollectionUnitTests.ts
+++ b/packages/core/services/mongodb-remote/__tests__/CoreRemoteMongoCollectionUnitTests.ts
@@ -179,6 +179,78 @@ describe("CoreRemoteMongoCollection", () => {
     }
   });
 
+  it("should find one", async () => {
+    const serviceMock = mock(CoreStitchServiceClientImpl);
+    const service = instance(serviceMock);
+
+    const client = new CoreRemoteMongoClientImpl(service);
+    const coll = getCollection(undefined, client);
+
+    const doc = { one: 1, two: 2 };
+
+    when(
+      serviceMock.callFunction(anything(), anything(), anything())
+    ).thenResolve(doc);
+
+    let result = await coll.findOne();
+    expect(result).toBeDefined();
+    expect(result).toEqual(doc);
+
+    const [funcNameArg, funcArgsArg, resultClassArg]: any[] = capture(
+      serviceMock.callFunction
+    ).last();
+
+    expect(funcNameArg).toEqual("findOne");
+    expect(funcArgsArg.length).toEqual(1);
+    const expectedArgs = {
+      collection: "collName1",
+      database: "dbName1",
+      query: {}
+    };
+    expect(funcArgsArg[0]).toEqual(expectedArgs);
+
+    const expectedFilter = { one: 1 };
+    const expectedProject = { two: "four" };
+    const expectedSort = { _id: -1 };
+
+    result = await coll.findOne(expectedFilter, {projection: expectedProject, sort: expectedSort});
+    expect(result).toEqual(doc);
+
+    verify(
+      serviceMock.callFunction(anything(), anything(), anything())
+    ).times(2);
+
+    const [funcNameArg2, funcArgsArg2, resultClassArg2]: any[] = capture(
+      serviceMock.callFunction
+    ).last();
+
+    expect("findOne").toEqual(funcNameArg2);
+    expect(1).toEqual(funcArgsArg2.length);
+    expectedArgs.query = expectedFilter;
+    expectedArgs.project = expectedProject;
+    expectedArgs.sort = expectedSort;
+    expect(funcArgsArg2[0]).toEqual(expectedArgs);
+
+    // Pass nothing
+    when(
+      serviceMock.callFunction(anything(), anything(), anything())
+    ).thenResolve(undefined);
+    result = await coll.findOne();
+    expect(result).toBeUndefined();
+
+    // Should pass along errors
+    when(
+      serviceMock.callFunction(anything(), anything(), anything())
+    ).thenReject(new Error("whoops"));
+
+    try {
+      await coll.find().first();
+      fail();
+    } catch (_) {
+      // Do nothing
+    }
+  });
+
   it("should aggregate", async () => {
     const serviceMock = mock(CoreStitchServiceClientImpl);
     const service = instance(serviceMock);

--- a/packages/core/services/mongodb-remote/__tests__/CoreRemoteMongoCollectionUnitTests.ts
+++ b/packages/core/services/mongodb-remote/__tests__/CoreRemoteMongoCollectionUnitTests.ts
@@ -231,13 +231,6 @@ describe("CoreRemoteMongoCollection", () => {
     expectedArgs.sort = expectedSort;
     expect(funcArgsArg2[0]).toEqual(expectedArgs);
 
-    // Pass nothing
-    when(
-      serviceMock.callFunction(anything(), anything(), anything())
-    ).thenResolve(undefined);
-    result = await coll.findOne();
-    expect(result).toBeUndefined();
-
     // Should pass along errors
     when(
       serviceMock.callFunction(anything(), anything(), anything())

--- a/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollection.ts
+++ b/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollection.ts
@@ -66,6 +66,17 @@ export default interface CoreRemoteMongoCollection<DocumentT> {
   ): CoreRemoteMongoReadOperation<DocumentT>;
 
   /**
+   * Finds one documents in the collection.
+   *
+   * @param query the query filter
+   * @return the resulting document or undefined if no such document exists
+   */
+  findOne(
+    query?: object,
+    options?: RemoteFindOptions
+  ): Promise<DocumentT | undefined>;
+
+  /**
    * Aggregates documents according to the specified aggregation pipeline.
    *
    * @param pipeline the aggregation pipeline

--- a/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollection.ts
+++ b/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollection.ts
@@ -69,12 +69,12 @@ export default interface CoreRemoteMongoCollection<DocumentT> {
    * Finds one documents in the collection.
    *
    * @param query the query filter
-   * @return the resulting document or undefined if no such document exists
+   * @return the resulting document or null if no such document exists
    */
   findOne(
     query?: object,
     options?: RemoteFindOptions
-  ): Promise<DocumentT | undefined>;
+  ): Promise<DocumentT | null>;
 
   /**
    * Aggregates documents according to the specified aggregation pipeline.

--- a/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
+++ b/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
@@ -100,6 +100,42 @@ export default class CoreRemoteMongoCollectionImpl<T>
   }
 
   /**
+   * Finds the documents in this collection which match the provided filter.
+   *
+   * - parameters:
+   *   - filter: A `Document` that should match the query.
+   *   - options: Optional `RemoteFindOptions` to use when executing the command.
+   *
+   * - important: Invoking this method by itself does not perform any network requests. You must call one of the
+   *              methods on the resulting `CoreRemoteMongoReadOperation` instance to trigger the operation against
+   *              the database.
+   *
+   * - returns: A `CoreRemoteMongoReadOperation` that allows retrieval of the resulting documents.
+   */
+  public findOne(
+    filter: object = {},
+    options?: RemoteFindOptions
+  ): Promise<T | undefined> {
+    const args: any = { ...this.baseOperationArgs };
+
+    args.query = filter;
+
+    if (options) {
+      if (options.projection) {
+        args.project = options.projection;
+      }
+      if (options.sort) {
+        args.sort = options.sort;
+      }
+    }
+    return this.service.callFunction(
+      "findOne",
+      [args],
+      this.codec
+    );
+  }
+
+  /**
    * Runs an aggregation framework pipeline against this collection.
    *
    * - Parameters:

--- a/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
+++ b/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
@@ -100,22 +100,18 @@ export default class CoreRemoteMongoCollectionImpl<T>
   }
 
   /**
-   * Finds the documents in this collection which match the provided filter.
+   * Finds a document in this collection which matches the provided filter.
    *
    * - parameters:
    *   - filter: A `Document` that should match the query.
    *   - options: Optional `RemoteFindOptions` to use when executing the command.
    *
-   * - important: Invoking this method by itself does not perform any network requests. You must call one of the
-   *              methods on the resulting `CoreRemoteMongoReadOperation` instance to trigger the operation against
-   *              the database.
-   *
-   * - returns: A `CoreRemoteMongoReadOperation` that allows retrieval of the resulting documents.
+   * - returns: A resulting `DocumentT` or null if the query returned zero matches.
    */
   public findOne(
     filter: object = {},
     options?: RemoteFindOptions
-  ): Promise<T | undefined> {
+  ): Promise<T | null> {
     const args: any = { ...this.baseOperationArgs };
 
     args.query = filter;

--- a/packages/react-native/core/package-lock.json
+++ b/packages/react-native/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongodb-stitch-react-native-core",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native/coretest/package-lock.json
+++ b/packages/react-native/coretest/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongodb-stitch-react-native-coretest",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native/services/aws-s3/package-lock.json
+++ b/packages/react-native/services/aws-s3/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongodb-stitch-react-native-services-aws-s3",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native/services/aws-ses/package-lock.json
+++ b/packages/react-native/services/aws-ses/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongodb-stitch-react-native-services-aws-ses",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native/services/aws/package-lock.json
+++ b/packages/react-native/services/aws/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongodb-stitch-react-native-services-aws",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native/services/http/package-lock.json
+++ b/packages/react-native/services/http/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongodb-stitch-react-native-services-http",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/react-native/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -200,7 +200,7 @@ describe("RemoteMongoClient", () => {
     const coll = getTestColl();
 
     let result = await coll.findOne();
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
 
     const doc1 = { hello: "world" };
     await coll.insertOne(doc1);
@@ -222,7 +222,7 @@ describe("RemoteMongoClient", () => {
     expect(withoutId(result)).toEqual(withoutId(doc2));
 
     result = await coll.findOne({notARealField: "bogus"});
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
 
     result = await coll.findOne({}, {sort: {_id: 1}})
     expect(result).toBeDefined();

--- a/packages/react-native/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/react-native/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -200,7 +200,7 @@ describe("RemoteMongoClient", () => {
     const coll = getTestColl();
 
     let result = await coll.findOne();
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
 
     const doc1 = { hello: "world" };
     await coll.insertOne(doc1);
@@ -222,7 +222,7 @@ describe("RemoteMongoClient", () => {
     expect(withoutId(result)).toEqual(withoutId(doc2));
 
     result = await coll.findOne({notARealField: "bogus"});
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
 
     result = await coll.findOne({}, {sort: {_id: 1}})
     expect(result).toBeDefined();

--- a/packages/react-native/services/mongodb-remote/package-lock.json
+++ b/packages/react-native/services/mongodb-remote/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongodb-stitch-react-native-services-mongodb-remote",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/react-native/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -101,12 +101,12 @@ export default interface RemoteMongoCollection<DocumentT> {
    * An empty query (`{}`) will match all documents.
    *
    * @param query the query filter
-   * @return the resulting document or undefined if the query resulted in zero matches
+   * @return the resulting document or null if the query resulted in zero matches
    */
   findOne(
     query?: object,
     options?: RemoteFindOptions
-  ): Promise<DocumentT | undefined>;
+  ): Promise<DocumentT | null>;
 
   /**
    * Aggregates documents according to the specified aggregation pipeline.

--- a/packages/react-native/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/react-native/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -96,6 +96,19 @@ export default interface RemoteMongoCollection<DocumentT> {
   ): RemoteMongoReadOperation<DocumentT>;
 
   /**
+   * Finds one document in the collection that matches the given query.
+   * 
+   * An empty query (`{}`) will match all documents.
+   *
+   * @param query the query filter
+   * @return the resulting document or undefined if the query resulted in zero matches
+   */
+  findOne(
+    query?: object,
+    options?: RemoteFindOptions
+  ): Promise<DocumentT | undefined>;
+
+  /**
    * Aggregates documents according to the specified aggregation pipeline.
    *
    * Stitch supports a subset of the available aggregation stages in MongoDB.

--- a/packages/react-native/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/react-native/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -83,6 +83,19 @@ export default class RemoteMongoCollectionImpl<DocumentT> {
   }
 
   /**
+   * Finds one document in the collection.
+   *
+   * @param query the query filter
+   * @return the resulting document or undefined if the query resulted in zero matches
+   */
+  public findOne(
+    query?: object,
+    options?: RemoteFindOptions
+  ): Promise<DocumentT | undefined> {
+    return this.proxy.findOne(query, options);
+  }
+
+  /**
    * Aggregates documents according to the specified aggregation pipeline.
    *
    * @param pipeline the aggregation pipeline

--- a/packages/react-native/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/react-native/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -86,12 +86,12 @@ export default class RemoteMongoCollectionImpl<DocumentT> {
    * Finds one document in the collection.
    *
    * @param query the query filter
-   * @return the resulting document or undefined if the query resulted in zero matches
+   * @return the resulting document or null if the query resulted in zero matches
    */
   public findOne(
     query?: object,
     options?: RemoteFindOptions
-  ): Promise<DocumentT | undefined> {
+  ): Promise<DocumentT | null> {
     return this.proxy.findOne(query, options);
   }
 

--- a/packages/react-native/services/twilio/package-lock.json
+++ b/packages/react-native/services/twilio/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongodb-stitch-react-native-services-twilio",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -195,6 +195,55 @@ describe("RemoteMongoClient", () => {
     }
   });
 
+  it("should find one", async () => {
+    const coll = getTestColl();
+
+    let result = await coll.findOne();
+    expect(result).toBeNull();
+
+    const doc1 = { hello: "world" };
+    await coll.insertOne(doc1);
+
+    result = await coll.findOne();
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc1));
+
+    
+    const doc2 = { hello: "world2", other: "other" };
+    await coll.insertOne(doc2);
+
+    result = await coll.findOne({hello: "world"});
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc1));
+
+    result = await coll.findOne({other: "other"})
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc2));
+
+    result = await coll.findOne({notARealField: "bogus"});
+    expect(result).toBeNull();
+
+    result = await coll.findOne({}, {sort: {_id: 1}})
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc1));
+
+    result = await coll.findOne({}, {sort: {_id: -1}})
+    expect(result).toBeDefined();
+    expect(withoutId(result)).toEqual(withoutId(doc2));
+
+    result = await coll.findOne(doc2, {projection: {_id: 0}});
+    expect(result).toBeDefined();
+    expect(result).toEqual(withoutId(doc2));
+
+    try {
+      await coll.find({ $who: 1 }).first();
+      fail();
+    } catch (error) {
+      expect(error instanceof StitchServiceError).toBeTruthy();
+      expect(StitchServiceErrorCode.MongoDBError).toEqual(error.errorCode);
+    }
+  });
+
   it("should aggregate", async () => {
     const coll = getTestColl();
     let iter = coll.aggregate([]);

--- a/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -199,7 +199,7 @@ describe("RemoteMongoClient", () => {
     const coll = getTestColl();
 
     let result = await coll.findOne();
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
 
     const doc1 = { hello: "world" };
     await coll.insertOne(doc1);
@@ -221,7 +221,7 @@ describe("RemoteMongoClient", () => {
     expect(withoutId(result)).toEqual(withoutId(doc2));
 
     result = await coll.findOne({notARealField: "bogus"});
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
 
     result = await coll.findOne({}, {sort: {_id: 1}})
     expect(result).toBeDefined();

--- a/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -199,7 +199,7 @@ describe("RemoteMongoClient", () => {
     const coll = getTestColl();
 
     let result = await coll.findOne();
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
 
     const doc1 = { hello: "world" };
     await coll.insertOne(doc1);
@@ -221,7 +221,7 @@ describe("RemoteMongoClient", () => {
     expect(withoutId(result)).toEqual(withoutId(doc2));
 
     result = await coll.findOne({notARealField: "bogus"});
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
 
     result = await coll.findOne({}, {sort: {_id: 1}})
     expect(result).toBeDefined();

--- a/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -101,12 +101,12 @@ export default interface RemoteMongoCollection<DocumentT> {
    * An empty query (`{}`) will match all documents.
    *
    * @param query the query filter
-   * @return the resulting document or undefined if the query resulted in zero matches
+   * @return the resulting document or null if the query resulted in zero matches
    */
   findOne(
     query?: object,
     options?: RemoteFindOptions
-  ): Promise<DocumentT | undefined>;
+  ): Promise<DocumentT | null>;
 
   /**
    * Aggregates documents according to the specified aggregation pipeline.

--- a/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -96,6 +96,19 @@ export default interface RemoteMongoCollection<DocumentT> {
   ): RemoteMongoReadOperation<DocumentT>;
 
   /**
+   * Finds one document in the collection that matches the given query.
+   * 
+   * An empty query (`{}`) will match all documents.
+   *
+   * @param query the query filter
+   * @return the resulting document or undefined if the query resulted in zero matches
+   */
+  findOne(
+    query?: object,
+    options?: RemoteFindOptions
+  ): Promise<DocumentT | undefined>;
+
+  /**
    * Aggregates documents according to the specified aggregation pipeline.
    *
    * Stitch supports a subset of the available aggregation stages in MongoDB.

--- a/packages/server/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/server/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -81,6 +81,19 @@ export default class RemoteMongoCollectionImpl<DocumentT> {
       this.proxy.find(query, options)
     );
   }
+   
+  /**
+   * Finds one document in the collection.
+   *
+   * @param query the query filter
+   * @return the resulting document or undefined if the query resulted in zero matches
+   */
+  public findOne(
+    query?: object,
+    options?: RemoteFindOptions
+  ): Promise<DocumentT | undefined> {
+    return this.proxy.findOne(query, options);
+  }
 
   /**
    * Aggregates documents according to the specified aggregation pipeline.

--- a/packages/server/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/server/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -86,12 +86,12 @@ export default class RemoteMongoCollectionImpl<DocumentT> {
    * Finds one document in the collection.
    *
    * @param query the query filter
-   * @return the resulting document or undefined if the query resulted in zero matches
+   * @return the resulting document or null if the query resulted in zero matches
    */
   public findOne(
     query?: object,
     options?: RemoteFindOptions
-  ): Promise<DocumentT | undefined> {
+  ): Promise<DocumentT | null> {
     return this.proxy.findOne(query, options);
   }
 


### PR DESCRIPTION
Not sure if this is a big deal/wrong, but the findOne() method returns null as opposed to undefined when there are no matching documents. We can discuss if this is not the right behaviour. 