### PR TITLE
 Wrap switchUserWithId in try catch

### DIFF
--- a/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
+++ b/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
@@ -390,7 +390,11 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
     if (credential.providerCapabilities.reusesExistingSession) {
       for (const [userId, authInfo] of this.allUsersAuthInfo) {
         if (authInfo.loggedInProviderType === credential.providerType) {
-          return Promise.resolve(this.switchToUserWithId(userId));
+          try {
+            return Promise.resolve(this.switchToUserWithId(userId));
+          } catch (error) {
+            return Promise.reject(error);
+          }
         }
       }
     }


### PR DESCRIPTION
If switchUserWithId throws one of its potential errors within the Promise.resolve, it goes unhandled and crashes the page.