### PR TITLE
DOCSP-4862 Add script to update browser sdk README versions

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -36,8 +36,11 @@ The [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.ht
 along with relevant permissions to the stitch-sdks bucket.
 
 ```bash
-lerna publish --force-publish="*"
 ./update_browser_readme_version.sh
+git add ../packages/browser/sdk/README.md
+git commit -m "Update SDK version in browser README"
+
+lerna publish --force-publish="*"
 ./publish_bundles.sh
 ./publish_docs.sh
 ```

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -45,6 +45,9 @@ lerna publish --force-publish="*"
 ./publish_docs.sh
 ```
 
+Note that update_browser_readme_version.sh will git commit its changes to the README automatically.
+It will fail out if there are currently other changes to tracked files.
+
 The `--force-publish="*"` argument ensures that all packages bump their version in lockstep.
 
 ### Patch Versions

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -37,6 +37,7 @@ along with relevant permissions to the stitch-sdks bucket.
 
 ```bash
 lerna publish --force-publish="*"
+./update_browser_readme_version.sh
 ./publish_bundles.sh
 ./publish_docs.sh
 ```

--- a/contrib/update_browser_readme_version.sh
+++ b/contrib/update_browser_readme_version.sh
@@ -15,4 +15,4 @@ echo "Setting README version to $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH..."
 sed -i '' \
   -e "s#\(stitch-sdks/js/bundles/\)[0-9\.]*\(/stitch\)#\1$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH\2#g" \
   ../packages/browser/sdk/README.md
-echo "README updated."
+echo "README updated. Remember to commit the change before publishing!"

--- a/contrib/update_browser_readme_version.sh
+++ b/contrib/update_browser_readme_version.sh
@@ -2,6 +2,13 @@
 
 cd "$(dirname "$0")"
 
+STATUS="$(git status -s)"
+if [ -n "$STATUS" ]; then
+  echo "Git status is not clean. Refusing to commit."
+  echo "Finish your work, then run $0"
+  exit 1
+fi
+
 # Paste the version string into the README.
 VERSION=`node -e 'console.log(require("../lerna.json").version)'` 
 VERSION_MAJOR=$(echo $VERSION | cut -d. -f1)
@@ -15,4 +22,13 @@ echo "Setting README version to $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH..."
 sed -i '' \
   -e "s#\(stitch-sdks/js/bundles/\)[0-9\.]*\(/stitch\)#\1$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH\2#g" \
   ../packages/browser/sdk/README.md
-echo "README updated. Remember to commit the change before publishing!"
+
+STATUS="$(git status -s)"
+if [ ! -n "$STATUS" ]; then
+  echo "Nothing to commit."
+  exit 0
+fi
+
+echo "README updated."
+git add -u "../packages/browser/sdk/README.md"
+git commit -m "Update browser README SDK version to $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH"

--- a/contrib/update_browser_readme_version.sh
+++ b/contrib/update_browser_readme_version.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+# Paste the version string into the README.
+VERSION=`node -e 'console.log(require("../lerna.json").version)'` 
+VERSION_MAJOR=$(echo $VERSION | cut -d. -f1)
+VERSION_MINOR=$(echo $VERSION | cut -d. -f2)
+VERSION_PATCH=$(echo $VERSION | cut -d. -f3 | cut -d- -f1)
+
+echo "Setting README version to $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH..."
+
+# Replace the occurences of stitch-sdks/js/bundles/<SOME VERSION>/stitch
+# with stitch-sdks/js/bundles/<CURRENT VERSION>/stitch
+sed -i '' \
+  -e "s#\(stitch-sdks/js/bundles/\)[0-9\.]*\(/stitch\)#\1$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH\2#g" \
+  ../packages/browser/sdk/README.md
+echo "README updated."


### PR DESCRIPTION
Please run contrib/update_browser_readme_version.sh when releasing/publishing
docs.