### PR TITLE
STITCH-2717 add support for compact watch streams

### DIFF
--- a/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/browser/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -868,8 +868,8 @@ describe("RemoteMongoClient", () => {
 
     const doc1 = { 
       _id: new BSON.ObjectID(),
+      greetings: "we come in peace",
       hello: "world",
-      greetings: "we come in peace"
     };
     expect(doc1._id).toEqual((await coll.insertOne(doc1)).insertedId);
 
@@ -919,11 +919,11 @@ describe("RemoteMongoClient", () => {
     const coll = getTestColl();
 
     const doc1 = { 
+      __stitch_sync_version: { 
+        id: (new BSON.ObjectID()).toHexString(), spv: 1, v: 3
+      },
       _id: new BSON.ObjectID(), 
       hello: "world",
-      __stitch_sync_version: { 
-        spv: 1, id: (new BSON.ObjectID()).toHexString(), v: 3
-      }
     };
     expect(doc1._id).toEqual((await coll.insertOne(doc1)).insertedId);
 
@@ -945,12 +945,12 @@ describe("RemoteMongoClient", () => {
   it("compact watch streams should include document hash for updates and inserts", async () => {
     const coll = getTestColl();
 
-    const doc1 = { 
+    const doc1 = {
+      __stitch_sync_version: { 
+        id: (new BSON.ObjectID()).toHexString(), spv: 1, v: 3
+      },
       _id: new BSON.ObjectID(), 
       hello: "world",
-      __stitch_sync_version: { 
-        spv: 1, id: (new BSON.ObjectID()).toHexString(), v: 3
-      }
     };
 
     const stream1 = await coll.watchCompact([doc1._id]);
@@ -968,12 +968,12 @@ describe("RemoteMongoClient", () => {
   it("compact watch streams should exclude document hash for deletes", async () => {
     const coll = getTestColl();
 
-    const doc1 = { 
+    const doc1 = {
+      __stitch_sync_version: { 
+        id: (new BSON.ObjectID()).toHexString(), spv: 1, v: 3
+      },
       _id: new BSON.ObjectID(), 
       hello: "world",
-      __stitch_sync_version: { 
-        spv: 1, id: (new BSON.ObjectID()).toHexString(), v: 3
-      }
     };
 
     await coll.insertOne(doc1)

--- a/packages/browser/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/browser/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -17,6 +17,7 @@
 import { Codec, Stream } from "mongodb-stitch-core-sdk";
 import {
   ChangeEvent,
+  CompactChangeEvent,
   RemoteCountOptions,
   RemoteDeleteResult,
   RemoteFindOneAndModifyOptions,
@@ -253,4 +254,31 @@ export default interface RemoteMongoCollection<DocumentT> {
    *         changes to the watched documents.
    */
   watch(ids: any[]): Promise<Stream<ChangeEvent<DocumentT>>>;
+
+  /**
+   * Opens a MongoDB change stream against the collection to watch for changes 
+   * made to specific documents. The documents to watch must be explicitly 
+   * specified by their _id.
+   * 
+   * Requests a stream where the full document of update events, and several 
+   * other unnecessary fields are omitted from the change event objects 
+   * returned by the server. This can save on network usage when watching
+   * large documents.
+   * 
+   * This method requires a browser that supports EventSource (server-sent 
+   * events). If you'd like this method to work in a browser that does not 
+   * support EventSource, you must provide a polyfill that makes 
+   * window.EventSource available. See
+   * [EventSource Browser Compatibility on MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventSource#Browser_compatibility)
+   * for information on which browsers support EventSource.
+   *
+   * @note
+   * This method does not support opening change streams on an entire collection
+   * or a specific query.
+   *
+   * @param ids the _ids of the documents to watch in this change stream
+   * @return a Promise containing a stream of compact change events 
+   *         representing the changes to the watched documents.
+   */
+  watchCompact(ids: any[]): Promise<Stream<CompactChangeEvent<DocumentT>>>;
 }

--- a/packages/browser/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/browser/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -25,7 +25,8 @@ import {
   RemoteInsertManyResult,
   RemoteInsertOneResult,
   RemoteUpdateOptions,
-  RemoteUpdateResult
+  RemoteUpdateResult,
+  CompactChangeEvent
 } from "mongodb-stitch-core-services-mongodb-remote";
 import RemoteMongoCollection from "../RemoteMongoCollection";
 import RemoteMongoReadOperation from "../RemoteMongoReadOperation";
@@ -235,25 +236,11 @@ export default class RemoteMongoCollectionImpl<DocumentT> {
     return this.proxy.updateMany(query, update, updateOptions);
   }
 
-  /**
-   * Opens a MongoDB change stream against the collection to watch for changes 
-   * made to specific documents. Please note that this method does not support 
-   * opening change streams on an entire collection or a specific query. The 
-   * documents to watch must be explicitly specified by their _id.
-   * 
-   * This method also requires a browser that supports EventSource (server-sent 
-   * events). If you'd like this method to work in a browser that does not 
-   * support EventSource, you must provide a polyfill that makes 
-   * window.EventSource available.
-   * 
-   * See https://developer.mozilla.org/en-US/docs/Web/API/EventSource#Browser_compatibility
-   * for more information on which browsers natively support EventSource.
-   * 
-   * @param ids the _ids of the documents to watch in this change stream
-   * @return a Promise containing a stream of change events representing the 
-   *         changes to the watched documents.
-   */
   public watch(ids: any[]): Promise<Stream<ChangeEvent<DocumentT>>> {
     return this.proxy.watch(ids);
+  }
+
+  public watchCompact(ids: any[]): Promise<Stream<CompactChangeEvent<DocumentT>>> {
+    return this.proxy.watchCompact(ids);
   }
 }

--- a/packages/browser/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/browser/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -17,6 +17,7 @@
 import { Codec, Stream } from "mongodb-stitch-core-sdk";
 import {
   ChangeEvent,
+  CompactChangeEvent,
   CoreRemoteMongoCollection,
   RemoteCountOptions,
   RemoteDeleteResult,
@@ -26,7 +27,6 @@ import {
   RemoteInsertOneResult,
   RemoteUpdateOptions,
   RemoteUpdateResult,
-  CompactChangeEvent
 } from "mongodb-stitch-core-services-mongodb-remote";
 import RemoteMongoCollection from "../RemoteMongoCollection";
 import RemoteMongoReadOperation from "../RemoteMongoReadOperation";

--- a/packages/core/services/mongodb-remote/src/CompactChangeEvent.ts
+++ b/packages/core/services/mongodb-remote/src/CompactChangeEvent.ts
@@ -14,25 +14,23 @@
  * limitations under the License.
  */
 
-
-import MongoNamespace from "./MongoNamespace";
 import { OperationType } from "./OperationType";
 import UpdateDescription from "./UpdateDescription";
 
 /**
- * Represents a change event communicated via a MongoDB change stream. This 
- * type of stream always includes a fullDocument for update events, and also 
- * includes the change event ID and namespace of the event as returned by 
- * MongoDB.
+ * Represents a change event communicated via a MongoDB change stream from 
+ * Stitch when watchCompact is called. These change events omit full documents 
+ * from the event for updates, as well as other fields that are unnecessary in 
+ * the context of Stitch.
  * 
  * @type T The underlying type of documents on the collection for which this 
  *         change event was produced.
  */
-export default interface ChangeEvent<T> {
-  readonly id: object;
+export default interface CompactChangeEvent<T> {
   readonly operationType: OperationType;
   readonly fullDocument?: T;
-  readonly namespace: MongoNamespace;
   readonly documentKey: object;
   readonly updateDescription?: UpdateDescription;
+  readonly stitchDocumentVersion?: object;
+  readonly stitchDocumentHash?: number;
 }

--- a/packages/core/services/mongodb-remote/src/index.ts
+++ b/packages/core/services/mongodb-remote/src/index.ts
@@ -15,6 +15,7 @@
  */
 
 import ChangeEvent from "./ChangeEvent";
+import CompactChangeEvent from "./CompactChangeEvent";
 import CoreRemoteMongoClient from "./internal/CoreRemoteMongoClient";
 import CoreRemoteMongoClientImpl from "./internal/CoreRemoteMongoClientImpl";
 import CoreRemoteMongoCollection from "./internal/CoreRemoteMongoCollection";
@@ -51,6 +52,7 @@ export {
   RemoteUpdateOptions,
   RemoteUpdateResult,
   ChangeEvent,
+  CompactChangeEvent,
   OperationType,
   MongoNamespace,
   UpdateDescription

--- a/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollection.ts
+++ b/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollection.ts
@@ -16,6 +16,7 @@
 
 import { Codec, Stream } from "mongodb-stitch-core-sdk";
 import ChangeEvent from "../ChangeEvent";
+import CompactChangeEvent from "../CompactChangeEvent";
 import RemoteCountOptions from "../RemoteCountOptions";
 import RemoteDeleteResult from "../RemoteDeleteResult";
 import RemoteFindOneAndModifyOptions from "../RemoteFindOneAndModifyOptions";
@@ -25,7 +26,6 @@ import RemoteInsertOneResult from "../RemoteInsertOneResult";
 import RemoteUpdateOptions from "../RemoteUpdateOptions";
 import RemoteUpdateResult from "../RemoteUpdateResult";
 import CoreRemoteMongoReadOperation from "./CoreRemoteMongoReadOperation";
-import CompactChangeEvent from "../CompactChangeEvent";
 
 /** @hidden */
 export default interface CoreRemoteMongoCollection<DocumentT> {

--- a/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollection.ts
+++ b/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollection.ts
@@ -25,6 +25,7 @@ import RemoteInsertOneResult from "../RemoteInsertOneResult";
 import RemoteUpdateOptions from "../RemoteUpdateOptions";
 import RemoteUpdateResult from "../RemoteUpdateResult";
 import CoreRemoteMongoReadOperation from "./CoreRemoteMongoReadOperation";
+import CompactChangeEvent from "../CompactChangeEvent";
 
 /** @hidden */
 export default interface CoreRemoteMongoCollection<DocumentT> {
@@ -201,4 +202,8 @@ export default interface CoreRemoteMongoCollection<DocumentT> {
   watch(
     ids: any[]
   ): Promise<Stream<ChangeEvent<DocumentT>>>;
+
+  watchCompact(
+    ids: any[]
+  ): Promise<Stream<CompactChangeEvent<DocumentT>>>;
 }

--- a/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
+++ b/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
@@ -28,6 +28,7 @@ import RemoteUpdateResult from "../RemoteUpdateResult";
 import CoreRemoteMongoCollection from "./CoreRemoteMongoCollection";
 import CoreRemoteMongoReadOperation from "./CoreRemoteMongoReadOperation";
 import ResultDecoders from "./ResultDecoders";
+import CompactChangeEvent from "../CompactChangeEvent";
 
 /** @hidden */
 export default class CoreRemoteMongoCollectionImpl<T>
@@ -418,6 +419,21 @@ export default class CoreRemoteMongoCollectionImpl<T>
       "watch",
       [args],
       new ResultDecoders.ChangeEventDecoder(this.codec)
+    );
+  }
+
+  public watchCompact(
+    ids: any[]
+  ): Promise<Stream<CompactChangeEvent<T>>> {
+    const args: any = { ...this.baseOperationArgs };
+
+    args.ids = ids;
+    args.useCompactEvents = true;
+
+    return this.service.streamFunction(
+      "watch",
+      [args],
+      new ResultDecoders.CompactChangeEventDecoder(this.codec)
     );
   }
 

--- a/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
+++ b/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
@@ -17,6 +17,7 @@
 import BSON from "bson";
 import { Codec, CoreStitchServiceClient, Stream } from "mongodb-stitch-core-sdk";
 import ChangeEvent from "../ChangeEvent";
+import CompactChangeEvent from "../CompactChangeEvent";
 import RemoteCountOptions from "../RemoteCountOptions";
 import RemoteDeleteResult from "../RemoteDeleteResult";
 import RemoteFindOneAndModifyOptions from "../RemoteFindOneAndModifyOptions";
@@ -28,7 +29,6 @@ import RemoteUpdateResult from "../RemoteUpdateResult";
 import CoreRemoteMongoCollection from "./CoreRemoteMongoCollection";
 import CoreRemoteMongoReadOperation from "./CoreRemoteMongoReadOperation";
 import ResultDecoders from "./ResultDecoders";
-import CompactChangeEvent from "../CompactChangeEvent";
 
 /** @hidden */
 export default class CoreRemoteMongoCollectionImpl<T>

--- a/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
+++ b/packages/core/services/mongodb-remote/src/internal/CoreRemoteMongoCollectionImpl.ts
@@ -414,6 +414,7 @@ export default class CoreRemoteMongoCollectionImpl<T>
     const args: any = { ...this.baseOperationArgs };
 
     args.ids = ids;
+    args.useCompactEvents = false;
 
     return this.service.streamFunction(
       "watch",

--- a/packages/core/services/mongodb-remote/src/internal/ResultDecoders.ts
+++ b/packages/core/services/mongodb-remote/src/internal/ResultDecoders.ts
@@ -16,13 +16,13 @@
 
 import { Assertions, Decoder } from "mongodb-stitch-core-sdk";
 import ChangeEvent from "../ChangeEvent";
-import { OperationType, operationTypeFromRemote } from "../OperationType";
+import CompactChangeEvent from "../CompactChangeEvent";
+import { operationTypeFromRemote } from "../OperationType";
 import RemoteDeleteResult from "../RemoteDeleteResult";
 import RemoteInsertManyResult from "../RemoteInsertManyResult";
 import RemoteInsertOneResult from "../RemoteInsertOneResult";
 import RemoteUpdateResult from "../RemoteUpdateResult";
 import UpdateDescription from "../UpdateDescription";
-import CompactChangeEvent from "../CompactChangeEvent";
 
 enum RemoteInsertManyResultFields {
   InsertedIds = "insertedIds"
@@ -218,9 +218,9 @@ class CompactChangeEventDecoder<T> implements Decoder<CompactChangeEvent<T>> {
       operationType: operationTypeFromRemote(
         from[CompactChangeEventFields.OperationType]
       ),
-      updateDescription,
+      stitchDocumentHash,
       stitchDocumentVersion,
-      stitchDocumentHash
+      updateDescription,
     };
   }
 }

--- a/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -34,7 +34,11 @@ import {
 import { BaseStitchServerIntTestHarness } from "mongodb-stitch-server-testutils";
 import { RemoteMongoClient, RemoteMongoCollection } from "../src";
 
-import { ChangeEvent } from "mongodb-stitch-core-services-mongodb-remote";
+import { 
+  ChangeEvent,
+  CompactChangeEvent,
+  OperationType 
+} from "mongodb-stitch-core-services-mongodb-remote";
 
 const mongodbUriProp = "TEST_STITCH_MONGODBURI";
 
@@ -818,17 +822,178 @@ describe("RemoteMongoClient", () => {
 
     await coll.updateMany({}, { $set: {hello: "multiverse"}});
   });
-/* tslint:enable:no-string-literal */
 
-it("issuing request with logged out user should reject promise", async () => {
-  const coll = getTestColl();
+  it("compact watch streams should include full document for inserts", async () => {
+    const coll = getTestColl();
 
-  expect(coll.findOne()).resolves.toBeNull();
+    const doc1 = { _id: new BSON.ObjectID(), hello: "world" };
+  
+    const stream1 = await coll.watchCompact([doc1._id]);
+    stream1.onNext((event: CompactChangeEvent<any>) => {
+      expect(event.documentKey["_id"]).toEqual(doc1._id);
+      expect(event.operationType).toEqual(OperationType.Insert);
+      expect(event.fullDocument).toMatchObject(doc1);
 
-  expect(harness.clients[0].auth.isLoggedIn).toEqual(true);
-  await harness.clients[0].auth.logout()
-  expect(harness.clients[0].auth.isLoggedIn).toEqual(false);
+      stream1.close();
+    });
 
-  expect(coll.findOne()).rejects.toBeTruthy();
-});
+    expect(doc1._id).toEqual((await coll.insertOne(doc1)).insertedId);
+  });
+
+  it("compact watch streams should exclude full document for updates", async () => {
+    const coll = getTestColl();
+
+    const doc1 = { _id: new BSON.ObjectID(), hello: "world" };
+    expect(doc1._id).toEqual((await coll.insertOne(doc1)).insertedId);
+
+    const stream1 = await coll.watchCompact([doc1._id]);
+    stream1.onNext((event: CompactChangeEvent<any>) => {
+      expect(event.documentKey["_id"]).toEqual(doc1._id);
+      expect(event.operationType).toEqual(OperationType.Update);
+      expect(event.fullDocument).toBeUndefined();
+
+      stream1.close();
+    });
+    await coll.updateOne({_id: doc1._id}, {$set: { hello: "universe"}});
+  });
+
+  it("compact watch streams should include detailed update description for updates", async () => {
+    const coll = getTestColl();
+
+    const doc1 = { 
+      _id: new BSON.ObjectID(),
+      hello: "world",
+      greetings: "we come in peace"
+    };
+    expect(doc1._id).toEqual((await coll.insertOne(doc1)).insertedId);
+
+    const stream1 = await coll.watchCompact([doc1._id]);
+    stream1.onNext((event: CompactChangeEvent<any>) => {
+      expect(event.documentKey["_id"]).toEqual(doc1._id);
+      expect(event.operationType).toEqual(OperationType.Update);
+      
+      expect(event.updateDescription.updatedFields["hello"]).toEqual("universe");
+      expect(event.updateDescription.removedFields.length).toEqual(1);
+      expect(
+        event.updateDescription.removedFields.includes("greetings")
+      ).toBeTruthy();
+
+      stream1.close();
+    });
+
+    await coll.updateOne(
+      {_id: doc1._id}, 
+      {
+        $set: { hello: "universe"},
+        $unset: { greetings: "" }
+      }
+    );
+  });
+
+  it("compact watch streams should exclude document version when not present", async () => {
+    const coll = getTestColl();
+
+    const doc1 = { _id: new BSON.ObjectID(), hello: "world" };
+    expect(doc1._id).toEqual((await coll.insertOne(doc1)).insertedId);
+
+    const stream1 = await coll.watchCompact([doc1._id]);
+    stream1.onNext((event: CompactChangeEvent<any>) => {
+      expect(event.documentKey["_id"]).toEqual(doc1._id);
+      expect(event.operationType).toEqual(OperationType.Update);
+      
+      expect(event.stitchDocumentVersion).toBeUndefined();
+
+      stream1.close();
+    });
+
+    await coll.updateOne({_id: doc1._id}, {$set: { hello: "universe"}});
+  });
+
+  it("compact watch streams should include document version when not present", async () => {
+    const coll = getTestColl();
+
+    const doc1 = { 
+      _id: new BSON.ObjectID(), 
+      hello: "world",
+      __stitch_sync_version: { 
+        spv: 1, id: (new BSON.ObjectID()).toHexString(), v: 3
+      }
+    };
+    expect(doc1._id).toEqual((await coll.insertOne(doc1)).insertedId);
+
+    const stream1 = await coll.watchCompact([doc1._id]);
+    stream1.onNext((event: CompactChangeEvent<any>) => {
+      expect(event.documentKey["_id"]).toEqual(doc1._id);
+      expect(event.operationType).toEqual(OperationType.Update);
+      
+      expect(event.stitchDocumentVersion).toMatchObject(
+        doc1.__stitch_sync_version
+      );
+
+      stream1.close();
+    });
+
+    await coll.updateOne({_id: doc1._id}, {$set: { hello: "universe"}});
+  });
+
+  it("compact watch streams should include document hash for updates and inserts", async () => {
+    const coll = getTestColl();
+
+    const doc1 = { 
+      _id: new BSON.ObjectID(), 
+      hello: "world",
+      __stitch_sync_version: { 
+        spv: 1, id: (new BSON.ObjectID()).toHexString(), v: 3
+      }
+    };
+
+    const stream1 = await coll.watchCompact([doc1._id]);
+    stream1.onNext((event: CompactChangeEvent<any>) => {
+      expect(event.documentKey["_id"]).toEqual(doc1._id);
+      expect(event.stitchDocumentHash).toBeDefined();
+
+      stream1.close();
+    });
+
+    await coll.insertOne(doc1)
+    await coll.updateOne({_id: doc1._id}, {$set: { hello: "universe"}});
+  });
+
+  it("compact watch streams should exclude document hash for deletes", async () => {
+    const coll = getTestColl();
+
+    const doc1 = { 
+      _id: new BSON.ObjectID(), 
+      hello: "world",
+      __stitch_sync_version: { 
+        spv: 1, id: (new BSON.ObjectID()).toHexString(), v: 3
+      }
+    };
+
+    await coll.insertOne(doc1)
+
+    const stream1 = await coll.watchCompact([doc1._id]);
+    stream1.onNext((event: CompactChangeEvent<any>) => {
+      expect(event.documentKey["_id"]).toEqual(doc1._id);
+      expect(event.operationType).toEqual(OperationType.Delete);
+      expect(event.stitchDocumentHash).toBeUndefined();
+
+      stream1.close();
+    });
+
+    await coll.deleteOne({_id: doc1._id});
+  });
+  /* tslint:enable:no-string-literal */
+
+  it("issuing request with logged out user should reject promise", async () => {
+    const coll = getTestColl();
+
+    expect(coll.findOne()).resolves.toBeNull();
+
+    expect(harness.clients[0].auth.isLoggedIn).toEqual(true);
+    await harness.clients[0].auth.logout()
+    expect(harness.clients[0].auth.isLoggedIn).toEqual(false);
+
+    expect(coll.findOne()).rejects.toBeTruthy();
+  });
 });

--- a/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
+++ b/packages/server/services/mongodb-remote/__tests__/RemoteMongoClientIntTests.ts
@@ -862,8 +862,8 @@ describe("RemoteMongoClient", () => {
 
     const doc1 = { 
       _id: new BSON.ObjectID(),
+      greetings: "we come in peace",
       hello: "world",
-      greetings: "we come in peace"
     };
     expect(doc1._id).toEqual((await coll.insertOne(doc1)).insertedId);
 
@@ -913,11 +913,11 @@ describe("RemoteMongoClient", () => {
     const coll = getTestColl();
 
     const doc1 = { 
+      __stitch_sync_version: { 
+        id: (new BSON.ObjectID()).toHexString(), spv: 1, v: 3
+      },
       _id: new BSON.ObjectID(), 
       hello: "world",
-      __stitch_sync_version: { 
-        spv: 1, id: (new BSON.ObjectID()).toHexString(), v: 3
-      }
     };
     expect(doc1._id).toEqual((await coll.insertOne(doc1)).insertedId);
 
@@ -939,12 +939,12 @@ describe("RemoteMongoClient", () => {
   it("compact watch streams should include document hash for updates and inserts", async () => {
     const coll = getTestColl();
 
-    const doc1 = { 
+    const doc1 = {
+      __stitch_sync_version: { 
+        id: (new BSON.ObjectID()).toHexString(), spv: 1, v: 3
+      },
       _id: new BSON.ObjectID(), 
       hello: "world",
-      __stitch_sync_version: { 
-        spv: 1, id: (new BSON.ObjectID()).toHexString(), v: 3
-      }
     };
 
     const stream1 = await coll.watchCompact([doc1._id]);
@@ -962,12 +962,12 @@ describe("RemoteMongoClient", () => {
   it("compact watch streams should exclude document hash for deletes", async () => {
     const coll = getTestColl();
 
-    const doc1 = { 
+    const doc1 = {
+      __stitch_sync_version: { 
+        id: (new BSON.ObjectID()).toHexString(), spv: 1, v: 3
+      },
       _id: new BSON.ObjectID(), 
       hello: "world",
-      __stitch_sync_version: { 
-        spv: 1, id: (new BSON.ObjectID()).toHexString(), v: 3
-      }
     };
 
     await coll.insertOne(doc1)

--- a/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -24,7 +24,8 @@ import {
   RemoteInsertManyResult,
   RemoteInsertOneResult,
   RemoteUpdateOptions,
-  RemoteUpdateResult
+  RemoteUpdateResult,
+  CompactChangeEvent
 } from "mongodb-stitch-core-services-mongodb-remote";
 import RemoteMongoReadOperation from "./RemoteMongoReadOperation";
 
@@ -244,4 +245,24 @@ export default interface RemoteMongoCollection<DocumentT> {
    *         changes to the watched documents.
    */
   watch(ids: any[]): Promise<Stream<ChangeEvent<DocumentT>>>;
+
+  /**
+   * Opens a MongoDB change stream against the collection to watch for changes 
+   * made to specific documents. The documents to watch must be explicitly 
+   * specified by their _id.
+   * 
+   * Requests a stream where the full document of update events, and several 
+   * other unnecessary fields are omitted from the change event objects 
+   * returned by the server. This can save on network usage when watching
+   * large documents.
+   *
+   * @note
+   * This method does not support opening change streams on an entire collection
+   * or a specific query.
+   *
+   * @param ids the _ids of the documents to watch in this change stream
+   * @return a Promise containing a stream of compact change events 
+   *         representing the changes to the watched documents.
+   */
+  watchCompact(ids: any[]): Promise<Stream<CompactChangeEvent<DocumentT>>>;
 }

--- a/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
+++ b/packages/server/services/mongodb-remote/src/RemoteMongoCollection.ts
@@ -17,6 +17,7 @@
 import { Codec, Stream } from "mongodb-stitch-core-sdk";
 import {
   ChangeEvent,
+  CompactChangeEvent,
   RemoteCountOptions,
   RemoteDeleteResult,
   RemoteFindOneAndModifyOptions,
@@ -25,7 +26,6 @@ import {
   RemoteInsertOneResult,
   RemoteUpdateOptions,
   RemoteUpdateResult,
-  CompactChangeEvent
 } from "mongodb-stitch-core-services-mongodb-remote";
 import RemoteMongoReadOperation from "./RemoteMongoReadOperation";
 

--- a/packages/server/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/server/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -25,7 +25,8 @@ import {
   RemoteInsertManyResult,
   RemoteInsertOneResult,
   RemoteUpdateOptions,
-  RemoteUpdateResult
+  RemoteUpdateResult,
+  CompactChangeEvent
 } from "mongodb-stitch-core-services-mongodb-remote";
 import RemoteMongoCollection from "../RemoteMongoCollection";
 import RemoteMongoReadOperation from "../RemoteMongoReadOperation";
@@ -247,5 +248,27 @@ export default class RemoteMongoCollectionImpl<DocumentT> {
    */
   public watch(ids: any[]): Promise<Stream<ChangeEvent<DocumentT>>> {
     return this.proxy.watch(ids);
+  }
+
+  /**
+   * Opens a MongoDB change stream against the collection to watch for changes 
+   * made to specific documents. The documents to watch must be explicitly 
+   * specified by their _id.
+   * 
+   * Requests a stream where the full document of update events, and several 
+   * other unnecessary fields are omitted from the change event objects 
+   * returned by the server. This can save on network usage when watching
+   * large documents.
+   *
+   * @note
+   * This method does not support opening change streams on an entire collection
+   * or a specific query.
+   *
+   * @param ids the _ids of the documents to watch in this change stream
+   * @return a Promise containing a stream of compact change events 
+   *         representing the changes to the watched documents.
+   */
+  public watchCompact(ids: any[]): Promise<Stream<CompactChangeEvent<DocumentT>>> {
+    return this.proxy.watchCompact(ids);
   }
 }

--- a/packages/server/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
+++ b/packages/server/services/mongodb-remote/src/internal/RemoteMongoCollectionImpl.ts
@@ -17,6 +17,7 @@
 import { Codec, Stream } from "mongodb-stitch-core-sdk";
 import {
   ChangeEvent,
+  CompactChangeEvent,
   CoreRemoteMongoCollection,
   RemoteCountOptions,
   RemoteDeleteResult,
@@ -26,7 +27,6 @@ import {
   RemoteInsertOneResult,
   RemoteUpdateOptions,
   RemoteUpdateResult,
-  CompactChangeEvent
 } from "mongodb-stitch-core-services-mongodb-remote";
 import RemoteMongoCollection from "../RemoteMongoCollection";
 import RemoteMongoReadOperation from "../RemoteMongoReadOperation";


### PR DESCRIPTION
This PR adds:

* `CompactChangeEvent` which is the type of event that compact streams return. 
    * Unlike Java and Swift, this does not share a base type with ChangeEvent. The code duplication is minimal in JS compared to Java and Swift
* a `CompactChangeEventDecoder` to `ResultDecoders` in the remote MongoDB service.
* an `UpdateDescriptionDecoder` to `ResultDecoders` to avoid duplicating code between the two change event decoders.
* `watchCompact` to the remote mongo collections in the browser and server SDKs
* Integration tests for `watchCompact` (@dkaminsky and I'm testing one thing per test 😄  )
* Unit tests for both `watch` and `watchCompact` since there was previously no unit test for `watch`