### PR TITLE
DOCSP-5313 Remove intercom bubble from docs and update feedback widget

### DIFF
--- a/contrib/docs-examples/checksum
+++ b/contrib/docs-examples/checksum
@@ -1,1 +1,1 @@
-a4fa2fafc83bfa36b518faaac6ed9e6a
+b9209ed9408e9a0da1e4361e164db43d

--- a/typedoc-theme/src/partials/rating-panel.hbs
+++ b/typedoc-theme/src/partials/rating-panel.hbs
@@ -2,45 +2,4 @@
 <div id="rating-panel" ></div>
 <link rel="stylesheet" href="{{relativeURL 'assets/css/feedback.css'}}" type="text/css" />
 <script type="text/javascript" src="{{relativeURL 'assets/js/feedback.min.js'}}"></script>
-
-<script>
-  window.intercomSettings = {
-    app_id: "u0ge9g70"
-  };
-</script>
-<script>
-(function() {
-  var w = window;
-
-  function l() {
-    var s = d.createElement("script");
-    s.type = "text/javascript";
-    s.async = true;
-    s.src = "https://widget.intercom.io/widget/u0ge9g70";
-    var x = d.getElementsByTagName("script")[0];
-    x.parentNode.insertBefore(s, x);
-  }
-  var ic = w.Intercom;
-  if (typeof ic === "function") {
-    ic("reattach_activator");
-    ic("update", intercomSettings);
-  } else {
-    var d = document;
-    var i = function() {
-      i.c(arguments);
-    };
-    i.q = [];
-    i.c = function(args) {
-      i.q.push(args);
-    };
-    w.Intercom = i;
-
-    if (w.attachEvent) {
-      w.attachEvent("onload", l);
-    } else {
-      w.addEventListener("load", l, false);
-    }
-  }
-})();
-</script>
 {{/if}}


### PR DESCRIPTION
The intercom trial is over, so this removes the intercom bubble.

This also (inadvertently*) updates the feedback widget.

*-but we wanted to anyway! See https://jira.mongodb.org/browse/DOCSP-5312

Intercom bubble is seen here:
![image](https://user-images.githubusercontent.com/20050130/56604080-2aab0f00-65cf-11e9-92fc-133ec13778d8.png)

Staged:

https://docs-mongodbcom-staging.corp.mongodb.com/stitch/bush/docsp-5313-remove-intercom/sdk/js/index.html

https://docs-mongodbcom-staging.corp.mongodb.com/stitch/bush/docsp-5313-remove-intercom/sdk/js-server/index.html

https://docs-mongodbcom-staging.corp.mongodb.com/stitch/bush/docsp-5313-remove-intercom/sdk/react-native/index.html