### PR TITLE
STITCH-4428: Create a service and rule before doing GQL tests

### DIFF
--- a/test/admin/graphql.test.js
+++ b/test/admin/graphql.test.js
@@ -14,14 +14,43 @@ describe('graphql', () => {
   beforeEach(async() => {
     const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
     th = await buildAdminTestHarness(true, apiKey, groupId, serverUrl);
+
+    const service = await th.app().services().create({
+      name: 'test',
+      type: 'mongodb',
+      config: {
+        uri: 'mongodb://localhost:26000'
+      }
+    });
+
+    await th.app().services().service(service._id).rules().create({
+      database: 'db',
+      collection: 'coll',
+      schema: {
+        properties: {
+          firstName: {
+            type: 'string'
+          }
+        }
+      }
+    });
+
     graphql = th.app().graphql();
   });
 
   afterEach(async() => th.cleanup());
 
   it('exposes a .post() which executes a graphql request', async() => {
-    const response = await graphql.post({ query: '{ __schema { types { name } } }' });
-    expect(response).toEqual({ data: {} });
+    const response = await graphql.post({ query: '{ __schema { queryType { name } } }' });
+    expect(response).toEqual({
+      data: {
+        __schema: {
+          queryType: {
+            name: 'Query'
+          }
+        }
+      }
+    });
   });
 
   it('exposes .validate() which properly executes the request to validate a schema', async() => {


### PR DESCRIPTION
The GraphQL endpoints will error if there's no mongo service with rules defined. We need to bootstrap the app for GQL before running these tests.