### PR TITLE
STITCH-4437: Add support for private admin triggers endpoints

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -8,14 +8,7 @@ import * as common from './common';
 import ExtJSON from 'mongodb-extjson';
 import queryString from 'query-string';
 import {StitchError, ErrInvalidSession, ErrUnauthorized} from './errors';
-
-const v1 = 1;
-const v2 = 2;
-const v3 = 3;
-const API_TYPE_PUBLIC = 'public';
-const API_TYPE_PRIVATE = 'private';
-const API_TYPE_CLIENT = 'client';
-const API_TYPE_APP = 'app';
+import { v1, v2, v3, API_TYPE_PUBLIC, API_TYPE_PRIVATE, API_TYPE_CLIENT, API_TYPE_APP } from './constants';
 
 export const fetcher = () => (typeof fetch === 'undefined' ? require('node-fetch') : fetch);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,9 @@
+const v1 = 1;
+const v2 = 2;
+const v3 = 3;
+const API_TYPE_PUBLIC = 'public';
+const API_TYPE_PRIVATE = 'private';
+const API_TYPE_CLIENT = 'client';
+const API_TYPE_APP = 'app';
+
+export { v1, v2, v3, API_TYPE_PUBLIC, API_TYPE_PRIVATE, API_TYPE_CLIENT, API_TYPE_APP };

--- a/test/admin/admin_triggers.test.js
+++ b/test/admin/admin_triggers.test.js
@@ -1,0 +1,107 @@
+const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
+import { buildAdminTestHarness, extractTestFixtureDataPoints } from '../testutil';
+import { StitchError, ErrUnauthorized } from '../../src/errors';
+
+function createSampleFunction(functions) {
+  return functions.create({
+    name: 'myFunction',
+    source: 'exports = () => {}'
+  });
+}
+
+function createSampleMongodbService(services) {
+  return services.create({
+    type: 'mongodb',
+    name: 'mdb',
+    config: {
+      uri: 'mongodb://localhost:26000'
+    }
+  });
+}
+
+function buildEventSubscriptionData(name, disabled, functionId, mongodbServiceId) {
+  return {
+    name,
+    type: 'DATABASE',
+    disabled,
+    function_id: functionId,
+    config: {
+      database: 'db',
+      collection: 'col',
+      operation_types: ['INSERT'],
+      service_id: mongodbServiceId
+    }
+  };
+}
+
+function comparePrivateAdminTriggersList(actualAdminTriggers, expectedAdminTriggers) {
+  expect(actualAdminTriggers).toHaveLength(expectedAdminTriggers.length);
+
+  actualAdminTriggers.forEach((actualAdminTrigger, index) => {
+    const expectedAdminTrigger = expectedAdminTriggers[index];
+    expect(actualAdminTrigger.name).toBe(expectedAdminTrigger.name);
+    expect(actualAdminTrigger.type).toBe(expectedAdminTrigger.type);
+    expect(actualAdminTrigger.status).toBe(expectedAdminTrigger.status);
+  });
+}
+
+describe('privateAdminTriggers', () => {
+  let test = new StitchMongoFixture({ userRoles: ['GLOBAL_OWNER'] });
+  let th;
+  let eventSubscriptions;
+  let functions;
+  let services;
+  let privateAdminTriggers;
+
+  beforeAll(() => test.setup(true));
+  afterAll(() => test.teardown());
+
+  beforeEach(async() => {
+    const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
+    th = await buildAdminTestHarness(true, apiKey, groupId, serverUrl);
+    eventSubscriptions = th.app().eventSubscriptions();
+    functions = th.app().functions();
+    services = th.app().services();
+    privateAdminTriggers = th.privateAdminTriggers();
+  });
+
+  afterEach(async() => th.cleanup());
+
+  it('should return all triggers belonging to the app when list is called', async() => {
+    const fn = await createSampleFunction(functions);
+    const mongodbService = await createSampleMongodbService(services);
+
+    const eventSubscriptionName1 = 'testAdminTriggers1';
+    const eventSubscriptionName2 = 'testAdminTriggers2';
+
+    await eventSubscriptions.create(buildEventSubscriptionData(eventSubscriptionName1, false, fn._id, mongodbService._id));
+    await eventSubscriptions.create(buildEventSubscriptionData(eventSubscriptionName2, true, fn._id, mongodbService._id));
+
+    const expectedPrivateAdminTriggers = [{ name: eventSubscriptionName1, type: 'DATABASE', state: 'UNOWNED'}, { name: eventSubscriptionName2, type: 'DATABASE', state: 'DISABLED'}];
+    const privateAdminTriggersList = await privateAdminTriggers.list();
+
+    comparePrivateAdminTriggersList(privateAdminTriggersList, expectedPrivateAdminTriggers);
+  });
+
+  it('should return an empty list when list is called and no triggers belong to the app', async() => {
+    const privateAdminTriggersList = await privateAdminTriggers.list();
+    expect(privateAdminTriggersList).toEqual([]);
+  });
+
+  it('should return a specific trigger when get is called', async() => {
+    const fn = await createSampleFunction(functions);
+    const mongodbService = await createSampleMongodbService(services);
+
+    const eventSubscriptionName = 'testAdminTriggers';
+    const eventSubscription = await eventSubscriptions.create(buildEventSubscriptionData(eventSubscriptionName, false, fn._id, mongodbService._id));
+
+    const privateAdminTriggersGet = await privateAdminTriggers.get(eventSubscription._id);
+    expect(privateAdminTriggersGet.name).toBe(eventSubscriptionName);
+    expect(privateAdminTriggersGet.type).toBe('DATABASE');
+    expect(privateAdminTriggersGet.state).toBe('UNOWNED');
+  });
+
+  it('should throw an error when get is called and the trigger does not exist', async() => {
+    await expect(privateAdminTriggers.get('1234')).rejects.toEqual(new StitchError('must provide valid trigger id (1234): invalid ObjectId', ErrUnauthorized));
+  });
+});

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,4 +1,6 @@
 const DEFAULT_URI = 'mongodb://localhost:26000/test';
 const DEFAULT_SERVER_URL = 'http://localhost:9090';
+const AUTH_DB = 'auth';
+const DEFAULT_USER_ROLES = ['groupOwner', 'GROUP_OWNER'];
 
-module.exports = { DEFAULT_URI, DEFAULT_SERVER_URL };
+module.exports = { DEFAULT_URI, DEFAULT_SERVER_URL, AUTH_DB, DEFAULT_USER_ROLES };

--- a/test/fixtures/stitch_mongo_fixture.js
+++ b/test/fixtures/stitch_mongo_fixture.js
@@ -1,7 +1,7 @@
 import { StitchAdminClientFactory } from '../../src/admin';
 const mongodb = require('mongodb');
 const MongoClient = mongodb.MongoClient;
-const { DEFAULT_URI, DEFAULT_SERVER_URL } = require('../constants');
+const { DEFAULT_URI, DEFAULT_SERVER_URL, DEFAULT_USER_ROLES } = require('../constants');
 const crypto = require('crypto');
 
 const randomString = length => {
@@ -21,11 +21,14 @@ const hashValue = (key, salt) => {
   });
 };
 
-export default class StitchFixture {
+export default class StitchMongoFixture {
   constructor(options) {
     options = options || {};
     options.mongoUri = options.mongoUri || DEFAULT_URI;
     options.baseUrl = options.baseUrl || DEFAULT_SERVER_URL;
+    const userRoles = options.userRoles || [];
+    options.userRoles = [...userRoles, ...DEFAULT_USER_ROLES];
+
     this.options = options;
     this.testNamespaces = [];
   }
@@ -81,7 +84,7 @@ export default class StitchFixture {
       userId: new mongodb.ObjectId().toHexString(),
       domainId: rootId,
       identities: [{ id: apiKeyId.toHexString(), providerType: 'api-key', providerId: rootProviderId }],
-      roles: [{ roleName: 'groupOwner', groupId }, { roleName: 'GROUP_OWNER', groupId }],
+      roles: this.options.userRoles.map(roleName => ({ roleName, groupId })),
       domain_id_hash: 3795608245,
       location: 'US-VA'
     };

--- a/test/testutil.js
+++ b/test/testutil.js
@@ -116,6 +116,10 @@ class TestHarness {
     return this.apps().app(this.testApp._id);
   }
 
+  privateAdminTriggers() {
+    return this.adminClient.privateAdminTriggers(this.groupId, this.testApp._id);
+  }
+
   async appRemove() {
     await this.app().remove();
     this.testApp = undefined;


### PR DESCRIPTION
Jira Ticket: https://jira.mongodb.org/browse/STITCH-4437

This ticket adds support for the endpoints necessary for the admin triggers console.