### PR TITLE
STITCH-4698 - change realm sdk methods to sync and add schema gen success test

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -466,18 +466,18 @@ export class StitchAdminClient extends StitchClient {
             };
           },
 
-          realm: () => {
-            const realmUrl = `${appUrl}/realm`;
+          sync: () => {
+            const syncUrl = `${appUrl}/sync`;
             return {
               config: () => {
-                const realmConfigUrl = `${realmUrl}/config`;
+                const realmConfigUrl = `${syncUrl}/config`;
                 return {
                   get: () => api._get(realmConfigUrl),
                   update: (data) => api._put(realmConfigUrl, { body: JSON.stringify(data) })
                 };
               },
               clientSchemas: () => {
-                const realmClientSchemasUrl = `${realmUrl}/client_schemas`;
+                const realmClientSchemasUrl = `${syncUrl}/client_schemas`;
                 return {
                   get: (language, filter) => api._get(`${realmClientSchemasUrl}/${language}`, filter)
                 };

--- a/test/admin/sync.test.js
+++ b/test/admin/sync.test.js
@@ -1,12 +1,12 @@
 const StitchMongoFixture = require('../fixtures/stitch_mongo_fixture');
 
-import { buildAdminTestHarness, extractTestFixtureDataPoints, createSampleMongodbService } from '../testutil';
+import { buildAdminTestHarness, extractTestFixtureDataPoints, createSampleMongodbService, addRuleToMongodbService } from '../testutil';
 
-describe('Realm', () => {
+describe('Sync', () => {
   let test = new StitchMongoFixture();
   let th;
-  let realmConfig;
-  let realmClientSchemas;
+  let syncConfig;
+  let syncClientSchemas;
   let services;
 
   beforeAll(() => test.setup());
@@ -15,28 +15,28 @@ describe('Realm', () => {
   beforeEach(async() => {
     const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
     th = await buildAdminTestHarness(true, apiKey, groupId, serverUrl);
-    realmConfig = th.app().realm().config();
-    realmClientSchemas = th.app().realm().clientSchemas();
+    syncConfig = th.app().sync().config();
+    syncClientSchemas = th.app().sync().clientSchemas();
     services = th.app().services();
   });
 
   afterEach(async() => th.cleanup());
 
   describe('config', () => {
-    it('exposes a .get() which returns the validation settings', async() => {
-      const config = await realmConfig.get();
+    it('exposes a .get() which returns the config settings', async() => {
+      const config = await syncConfig.get();
       expect(config).toEqual({
         development_mode_enabled: false
       });
     });
 
-    it('exposes an .update() which sets the validation settings', async() => {
+    it('exposes an .update() which sets the config settings', async() => {
       const newConfig = {
         development_mode_enabled: true
       };
 
-      await realmConfig.update(newConfig);
-      const updatedConfig = await realmConfig.get();
+      await syncConfig.update(newConfig);
+      const updatedConfig = await syncConfig.get();
       expect(updatedConfig).toEqual(newConfig);
     });
   });
@@ -45,7 +45,7 @@ describe('Realm', () => {
     describe('.get()', async() => {
       it('should return a 400 error if called with an unsupported language', async() => {
         try {
-          await realmClientSchemas.get('PERL');
+          await syncClientSchemas.get('PERL');
         } catch (e) {
           expect(e.response.status).toEqual(400);
           expect(e.message).toEqual("Unsupported client language: 'PERL'");
@@ -54,7 +54,7 @@ describe('Realm', () => {
 
       it('should return a 500 error if called when no MongoDB service exists', async() => {
         try {
-          await realmClientSchemas.get('KOTLIN');
+          await syncClientSchemas.get('KOTLIN');
         } catch (e) {
           expect(e.response.status).toEqual(500);
           expect(e.message).toEqual('error processing request');
@@ -66,11 +66,20 @@ describe('Realm', () => {
         await createSampleMongodbService(services);
 
         try {
-          await realmClientSchemas.get('KOTLIN');
+          await syncClientSchemas.get('KOTLIN');
         } catch (e) {
           expect(e.response.status).toEqual(500);
           expect(e.message).toEqual('error processing request');
         }
+      });
+
+      it('should succed with a supported language and and rules', async() => {
+        // Setup MongoDB service
+        const mongoDBService = await createSampleMongodbService(services);
+        await addRuleToMongodbService(services, mongoDBService, {database: 'foo', collection: 'bar'});
+        const schemas =  await syncClientSchemas.get('KOTLIN');
+        expect(schemas.length).toEqual(1);
+        console.log(schemas);
       });
     });
   });

--- a/test/admin/sync.test.js
+++ b/test/admin/sync.test.js
@@ -79,7 +79,6 @@ describe('Sync', () => {
         await addRuleToMongodbService(services, mongoDBService, {database: 'foo', collection: 'bar'});
         const schemas =  await syncClientSchemas.get('KOTLIN');
         expect(schemas.length).toEqual(1);
-        console.log(schemas);
       });
     });
   });


### PR DESCRIPTION
Since we now have sync config/methods under sync instead of realm we need to change the sdk to support it

Also now that we have language support, we can add a sync schema gen success test for the sdk