### PR TITLE
REALMC-5056 -  support queryParams for service delete and rule create, update, delete

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -280,7 +280,7 @@ export class StitchAdminClient extends StitchClient {
             create: data => api._post(`${appUrl}/services`, data),
             service: serviceId => ({
               get: () => api._get(`${appUrl}/services/${serviceId}`),
-              remove: () => api._delete(`${appUrl}/services/${serviceId}`),
+              remove: (params) => api._delete(`${appUrl}/services/${serviceId}`, params),
               update: data =>
                 api._patch(`${appUrl}/services/${serviceId}`, {
                   body: JSON.stringify(data)
@@ -297,13 +297,13 @@ export class StitchAdminClient extends StitchClient {
 
               rules: () => ({
                 list: () => api._get(`${appUrl}/services/${serviceId}/rules`),
-                create: data => api._post(`${appUrl}/services/${serviceId}/rules`, data),
+                create: (data, params) => api._post(`${appUrl}/services/${serviceId}/rules`, data, params),
                 rule: ruleId => {
                   const ruleUrl = `${appUrl}/services/${serviceId}/rules/${ruleId}`;
                   return {
                     get: () => api._get(ruleUrl),
-                    update: data => api._put(ruleUrl, { body: JSON.stringify(data) }),
-                    remove: () => api._delete(ruleUrl)
+                    update: (data, params) => api._put(ruleUrl, { body: JSON.stringify(data), queryParams: params }),
+                    remove: (params) => api._delete(ruleUrl, params)
                   };
                 }
               }),

--- a/test/testutil.js
+++ b/test/testutil.js
@@ -69,9 +69,9 @@ export const createSampleMongodbSyncService = async(services, partitionKey = 'ke
   return syncService;
 };
 
-export const addRuleToMongodbService = async(services, mongodbService, { database, collection, config }) => {
+export const addRuleToMongodbService = async(services, mongodbService, { database, collection, config }, params) => {
   const mongoSvcObj = services.service(mongodbService._id);
-  await mongoSvcObj.rules().create(Object.assign({}, config, { database, collection }));
+  return await mongoSvcObj.rules().create(Object.assign({}, config, { database, collection }), params);
 };
 
 class TestHarness {


### PR DESCRIPTION
This update adds query param support for:
- service delete
- rule create/update/delete

With this we can run those functions `allow_destructive_changes` when we want to ignore a destructive sync error.

As this update is not implementation specific, and since the idea of what is or is not destructive has not been finalized yet I opted not to add tests. Let me know if there's a better way to test or mock general param behavior!