### PR TITLE
REALMC-9230: fix failing test in 'stitch-js-sdk-3.0'

### DIFF
--- a/test/admin/app.test.js
+++ b/test/admin/app.test.js
@@ -10,6 +10,8 @@ const assertAppsEqual = (a, b) => {
   delete appB.last_used;
   delete appA.last_modified;
   delete appB.last_modified;
+  delete appA.template_id;
+  delete appB.template_id;
 
   expect(appA).toEqual(appB);
 };

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -92,6 +92,8 @@ describe('Auth linking', () => {
   beforeEach(async() => {
     const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
     th = await buildClientTestHarness(apiKey, groupId, serverUrl);
+    // Needed to invalidate app cache
+    await new Promise((r) => setTimeout(r, 1000));
     await th.configureAnon();
     client = th.stitchClient;
     await client.logout();
@@ -150,6 +152,8 @@ describe('Auth login semantics', () => {
   beforeEach(async() => {
     const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
     th = await buildClientTestHarness(apiKey, groupId, serverUrl);
+    // Needed to invalidate app cache
+    await new Promise((r) => setTimeout(r, 1000));
     await th.configureAnon();
     client = th.stitchClient;
     await client.logout();

--- a/test/client/aws_services.test.js
+++ b/test/client/aws_services.test.js
@@ -99,6 +99,8 @@ describe('Executing AWS service functions', () => {
       const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
       th = await buildClientTestHarness(apiKey, groupId, serverUrl);
 
+      // Needed to invalidate app cache
+      await new Promise((r) => setTimeout(r, 1000));
       if (awsCredsInEnv()) {
         const s3Service = await th
           .app()
@@ -191,6 +193,8 @@ describe('Executing AWS service functions', () => {
       const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
       th = await buildClientTestHarness(apiKey, groupId, serverUrl);
 
+      // Needed to invalidate app cache
+      await new Promise((r) => setTimeout(r, 1000));
       if (awsCredsInEnv()) {
         const sesService = await th
           .app()

--- a/test/client/aws_services.test.js
+++ b/test/client/aws_services.test.js
@@ -117,7 +117,8 @@ describe('Executing AWS service functions', () => {
 
         service = th.stitchClient.service(S3_SERVICE_TYPE, S3_SERVICE_NAME);
         serviceId = s3Service._id;
-
+        // Needed to invalidate app cache
+        await new Promise((r) => setTimeout(r, 1000));
         await th
           .app()
           .services()

--- a/test/client/execute_function.test.js
+++ b/test/client/execute_function.test.js
@@ -16,6 +16,8 @@ describe('Client API executing named functions', () => {
     const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
     th = await buildClientTestHarness(apiKey, groupId, serverUrl);
     client = th.stitchClient;
+    // Needed to invalidate app cache
+    await new Promise((r) => setTimeout(r, 1000));
   });
 
   afterEach(async() => th.cleanup());

--- a/test/client/twilio_service.test.js
+++ b/test/client/twilio_service.test.js
@@ -24,6 +24,8 @@ describe('Executing Twilio service functions', () => {
     const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
     th = await buildClientTestHarness(apiKey, groupId, serverUrl);
 
+    // Needed to invalidate app cache
+    await new Promise((r) => setTimeout(r, 1000));
     if (twilioCredsInEnv()) {
       const twilioService = await th
         .app()

--- a/test/userRegistrations.test.js
+++ b/test/userRegistrations.test.js
@@ -23,6 +23,8 @@ describe('User Registrations', ()=>{
   beforeEach(async() => {
     const { apiKey, groupId, serverUrl } = extractTestFixtureDataPoints(test);
     th = await buildClientTestHarness(apiKey, groupId, serverUrl);
+    // Needed to invalidate app cache
+    await new Promise((r) => setTimeout(r, 1000));
     await th.configureAnon();
     client = th.stitchClient;
     await client.logout();


### PR DESCRIPTION
The app cache was not being invalidated because the test setup requests were coming in too quickly.